### PR TITLE
Bug: MultiStep form incorrectly submitting and caching data

### DIFF
--- a/src/hooks/useMultiStepForm.js
+++ b/src/hooks/useMultiStepForm.js
@@ -29,7 +29,7 @@ function useMultStepForm(uuid) {
     if (formData.currentStep < TOTAL_STEPS) {
       const nextStep = formData.currentStep + 1;
       setFormData({ ...formData, currentStep: nextStep });
-      updateOfflineData("formData", { ...formData, uuid, currentStep: nextStep });
+      updateOfflineData("formData", [{ ...formData, uuid, currentStep: nextStep }]);
     }
   }
 
@@ -37,8 +37,7 @@ function useMultStepForm(uuid) {
     if (formData.currentStep > 1) {
       const prevStep = formData.currentStep - 1;
       setFormData({ ...formData, currentStep: prevStep });
-      updateOfflineData("formData", { ...formData, uuid, currentStep: prevStep });
-      return;
+      updateOfflineData("formData", [{ ...formData, uuid, currentStep: prevStep }]);
     }
   }
 

--- a/src/pages/MultiStepForm.example.jsx
+++ b/src/pages/MultiStepForm.example.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { TextInput, Button, Label, ErrorMessage } from "../react-radfish";
-import { GridContainer, Grid } from "@trussworks/react-uswds";
+import { GridContainer, Grid, FormGroup } from "@trussworks/react-uswds";
 import {
   fullNameValidators,
   emailValidators,
@@ -11,7 +11,7 @@ import {
 } from "../utilities";
 import useOfflineStorage from "../hooks/useOfflineStorage";
 import { CONSTANTS } from "../config/multistepForm";
-import useMultStepForm from "../hooks/useMultiStepForm";
+import useMultiStepForm from "../hooks/useMultiStepForm";
 import { useParams, useNavigate } from "react-router-dom";
 
 const { fullName, nickname, email, phoneNumber, country, city, state, zipcode } = CONSTANTS;
@@ -38,7 +38,7 @@ const MultiStepForm = () => {
     handleChange,
     handleBlur,
     validationErrors,
-  } = useMultStepForm(id);
+  } = useMultiStepForm(id);
 
   // A Ref will be needed for each step form to set focus when the form is displayed.
   const stepFocus = [useRef(null), useRef(null), useRef(null)];
@@ -79,7 +79,7 @@ const MultiStepForm = () => {
     );
   }
 
-  if (formData || formData.currentStep === 1) {
+  if (formData.currentStep === 1) {
     return (
       <GridContainer>
         <Grid row gap="md">
@@ -132,10 +132,14 @@ const MultiStepForm = () => {
             to move the button to the right to give the correct placement on page while tabbing
             in the correct order.
           */}
-          <Button className="margin-top-1 margin-right-0 order-last" onClick={stepForward}>
+          <Button
+            type="button"
+            className="margin-top-1 margin-right-0 order-last"
+            onClick={stepForward}
+          >
             Next Step
           </Button>
-          <Button className="margin-top-1" onClick={stepBackward}>
+          <Button type="button" className="margin-top-1" onClick={stepBackward}>
             Prev Step
           </Button>
         </Grid>
@@ -193,10 +197,14 @@ const MultiStepForm = () => {
           </Grid>
         </Grid>
         <Grid className="display-flex flex-justify">
-          <Button className="margin-top-1 margin-right-0 order-last" onClick={stepForward}>
+          <Button
+            type="button"
+            className="margin-top-1 margin-right-0 order-last"
+            onClick={stepForward}
+          >
             Next Step
           </Button>
-          <Button className="margin-top-1" onClick={stepBackward}>
+          <Button type="button" className="margin-top-1" onClick={stepBackward}>
             Prev Step
           </Button>
         </Grid>
@@ -295,7 +303,7 @@ const MultiStepForm = () => {
           >
             Submit MultiStep Form
           </Button>
-          <Button className="margin-top-1" onClick={stepBackward}>
+          <Button type="button" className="margin-top-1" onClick={stepBackward}>
             Prev Step
           </Button>
         </Grid>

--- a/src/storage/IndexedDBMethod.js
+++ b/src/storage/IndexedDBMethod.js
@@ -59,8 +59,7 @@ export class IndexedDBMethod extends StorageMethod {
   /**
    * Update data in IndexedDB.
    * @param {string} tableName - The name of the table to find data.
-   * @param {Array} criteria - The criteria to use for updating data, e.g. ["uuid-123"] or ["uuid-123", "uuid-987", "uuid-456"].
-   * @param {Array} data - Array of the updated data, e.g. [{ numberOfFish: "1", species: "Grouper" }] or [{name: "Grouper", price: 5.00}, {name: "Salmon", price: 10.00}].
+   * @param {Array} data - Array of the updated data, e.g. [{ uuid: 1234, numberOfFish: "1", species: "Grouper" }] or [{ uuid: 5678, name: "Grouper", price: 5.00}, { uuid: 9012, name: "Salmon", price: 10.00 }]. Be sure the uuid is included in each data object.
    * @return {Promise<Array>} A promise that resolves to the updated data.
    * @throws {Error} If an error occurs while updating the data in IndexedDB.
    */


### PR DESCRIPTION
This bug ticket fixes a few issues reported by Steve in Google Chat:

![image](https://github.com/NMFS-RADFish/boilerplate/assets/35090461/6389a315-c520-4897-92ca-978716c5a45c)

Changes:

1. Multistep form `Button` components that progress step, but do not submit form need to be assigned a `type="button"` prop, else they we submit the form by default.

2. When updating cached data via indexDB `update` method, we need to pass an array of data objects, rather than a single data object, since we are using `bulkUpdate` under the hood for performance reasons.

3. Adds missing import of `FormGroup` that got lost during a merge to main, this was causing the multistep to break and render a WSOD

I'm not sure what he means by "allows user to enter any page number to navigate to non-exsistent pages". I will try to follow up in Google chat directly