### PR TITLE
Brock - Dogfooding Exercise DO NOT MERGE

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { MultiStepForm } from "./pages/MultiStepForm.example";
 import { SimpleTable } from "./pages/Table.example";
 import useOfflineStorage from "./hooks/useOfflineStorage.example";
 import { SetsTable } from "./pages/SetsTable";
+import { CoolForm } from "./pages/CoolForm";
 
 const ApiService = new RadfishAPIService("");
 
@@ -162,6 +163,14 @@ function App() {
               element={
                 <FormWrapper onSubmit={handleFormSubmit}>
                   <ComplexForm asyncFormOptions={asyncFormOptions} />
+                </FormWrapper>
+              }
+            />
+            <Route
+              path="/coolform"
+              element={
+                <FormWrapper onSubmit={handleFormSubmit}>
+                  <CoolForm asyncFormOptions={asyncFormOptions} />
                 </FormWrapper>
               }
             />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { ComplexForm } from "./pages/ComplexForm.example";
 import { MultiStepForm } from "./pages/MultiStepForm.example";
 import { SimpleTable } from "./pages/Table.example";
 import useOfflineStorage from "./hooks/useOfflineStorage.example";
+import { SetsTable } from "./pages/SetsTable";
 
 const ApiService = new RadfishAPIService("");
 
@@ -44,7 +45,7 @@ function App() {
 
   const handleOffline = () => {
     setIsOffline(true);
-    const { status, message } = ToastStatus.OFFLINE;
+    const { status, message } = TOAST_CONFIG.OFFLINE;
     setToast({ status, message });
   };
 
@@ -98,10 +99,10 @@ function App() {
   const handleFormSubmit = async (submittedData) => {
     try {
       await ApiService.post(MSW_ENDPOINT.SPECIES, submittedData);
-      const { status, message } = ToastStatus.SUCCESS;
+      const { status, message } = TOAST_CONFIG.SUCCESS;
       setToast({ status, message });
     } catch (err) {
-      const { status, message } = ToastStatus.ERROR;
+      const { status, message } = TOAST_CONFIG.ERROR;
       setToast({ status, message });
     } finally {
       setTimeout(() => {
@@ -123,9 +124,9 @@ function App() {
             <Route
               path="/"
               element={
-                <FormWrapper onSubmit={handleFormSubmit}>
-                  <ComplexForm asyncFormOptions={asyncFormOptions} />
-                </FormWrapper>
+                <TableWrapper>
+                  <SetsTable />
+                </TableWrapper>
               }
             />
             {/* On "/table" route, render the DemoTable component along with it's context for state management */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { Routes, Route, BrowserRouter as Router } from "react-router-dom";
 import { Toast, ToastStatus } from "./packages/react-components";
 import { FormWrapper } from "./contexts/FormWrapper.example";
 import { TableWrapper } from "./contexts/TableWrapper.example";
+import { SetsTableWrapper } from "./contexts/SetsTableWrapper";
 import Layout from "./components/Layout";
 import RadfishAPIService from "./packages/services/APIService";
 import { MSW_ENDPOINT } from "./mocks/handlers";
@@ -66,6 +67,7 @@ function App() {
   useEffect(() => {
     // this function fetches any data needed for the business requirements in DemoForm
     const fetchFormData = async () => {
+      const setsData = await ApiService.get(MSW_ENDPOINT.SETS);
       const { data } = await ApiService.get(MSW_ENDPOINT.SPECIES);
       const milisecondsIn24Hours = 86400000;
       const currentTimeStamp = Date.now();
@@ -92,6 +94,7 @@ function App() {
           localStorage.setItem("speciesLastUpdated", currentTimeStamp);
         }
       }
+      await updateOfflineData("sets", setsData.data);
     };
     fetchFormData();
   }, [isOffline]);
@@ -124,9 +127,9 @@ function App() {
             <Route
               path="/"
               element={
-                <TableWrapper>
+                <SetsTableWrapper>
                   <SetsTable />
-                </TableWrapper>
+                </SetsTableWrapper>
               }
             />
             {/* On "/table" route, render the DemoTable component along with it's context for state management */}

--- a/src/config/form.js
+++ b/src/config/form.js
@@ -1,5 +1,5 @@
 const CONSTANTS = {
-  fullName: "fullName",
+  middleName: "middleName",
   nickname: "nickname",
   email: "email",
   phoneNumber: "phoneNumber",
@@ -58,7 +58,7 @@ const computePriceFromQuantitySpecies = (values) => {
 };
 
 const FORM_CONFIG = {
-  [CONSTANTS.fullName]: {
+  [CONSTANTS.middleName]: {
     visibility: null,
     computed: null,
     validation: null,

--- a/src/contexts/FormWrapper.example.jsx
+++ b/src/contexts/FormWrapper.example.jsx
@@ -31,6 +31,7 @@ export const FormWrapper = ({ children, onSubmit }) => {
       Object.entries(FORM_CONFIG).map(([key, config]) => [key, config.visibility?.visibleOnMount]),
     ),
   );
+  console.log(visibleInputs);
   const [validationErrors, setValidationErrors] = useState({});
   const navigate = useNavigate();
   const params = useParams();

--- a/src/contexts/SetsTableWrapper.jsx
+++ b/src/contexts/SetsTableWrapper.jsx
@@ -1,0 +1,127 @@
+/**
+ * Manages state for any child Radfish table.
+ * This context should wrap the RadfishTable component and will manage it's state related to column headers, data cells, and sorting/filtering
+ * This context provider is meant to be extensible and modular. You can use this anywhere in your app by wrapping a table to manage that table's state
+ */
+
+import React, { createContext } from "react";
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  getPaginationRowModel,
+} from "@tanstack/react-table";
+
+/**
+ * Creates a column helper instance.
+ * @type {import("@tanstack/react-table").ColumnHelper}
+ */
+const columnHelper = createColumnHelper();
+
+/**
+ * Context for the table component.
+ * @type {React.Context<object>}
+ */
+const TableContext = createContext();
+
+/**
+ * Wrapper component for a table.
+ * @param {children} - The child component that needs it's state managed, this should be the RadfishTable component.
+ */
+export const SetsTableWrapper = ({ children }) => {
+  const [data, setData] = React.useState([]);
+  const [sorting, setSorting] = React.useState([]);
+  const [showOfflineSubmit, setShowOfflineSubmit] = React.useState(false);
+  const [pagination, setPagination] = React.useState({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
+  /**
+   * Defines the columns for the table. This needs to be memoized for performance reasons.
+   * Column helper accessors should reference the keys of each object within the data of the form.
+   * This will allow the form to understand which column headers to create.
+   * For instance:
+   * const data = [
+      {
+        species: "Grouper",
+        count: 10,
+      },
+   */
+  const columns = React.useMemo(
+    () => [
+      columnHelper.accessor("isOffline", {
+        cell: (info) => (info.getValue() ? "Draft " : "Submitted"),
+        header: () => <span>Status</span>,
+      }),
+      columnHelper.accessor("id", {
+        cell: (info) => info.getValue(),
+        header: () => <span>Id</span>,
+      }),
+      columnHelper.accessor("setStatus", {
+        cell: (info) => info.getValue(),
+        header: () => <span>Status</span>,
+      })
+    ],
+    [],
+  );
+
+  /**
+   * React Table instance. Initializes the table with the data being managed in TableWrapper state
+   * Columns are set to the memoized value returned from the useMemo hook above
+   * state and helper methods are to provide helper methods to render data, and re-render based on sorting functionality
+   */
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      pagination,
+    },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: setPagination,
+  });
+
+  /**
+   * headerNames and rowModel are the result of two helper methods that make rendering table data simpler.
+   *
+   */
+  const headerNames = table.getFlatHeaders();
+  const rowModel = table.getRowModel();
+
+  /**
+   * Context value for the table.
+   * @type {object}
+   * @property {string} tableCaption - Caption for the table.
+   * @property {TableInstance} table - The React Table instance. Returned value from useReactTable hook.
+   * @property {Function} setData - Function to set table data. This can be initialized from cached data or API call.
+   */
+  const contextValue = {
+    tableCaption: "This table shows how many of each fish species were caught",
+    table,
+    headerNames,
+    rowModel,
+    setData,
+    showOfflineSubmit,
+    setShowOfflineSubmit,
+  };
+
+  return <TableContext.Provider value={contextValue}>{children}</TableContext.Provider>;
+};
+
+/**
+ * Hook to access the table state within the TableWrapper context.
+ * @returns {object} - The context containing table state.
+ * @throws {Error} - Throws error if used outside TableWrapper context.
+ */
+export const useTableState = () => {
+  const context = React.useContext(TableContext);
+  if (!context) {
+    throw new Error("useTableState must be used within a TableWrapper context");
+  }
+  return context;
+};

--- a/src/hooks/useOfflineStorage.example.js
+++ b/src/hooks/useOfflineStorage.example.js
@@ -33,11 +33,12 @@ function useOfflineStorage() {
    */
   const storageMethod = new IndexedDBMethod(
     import.meta.env.VITE_INDEXED_DB_NAME || "radfish_dev",
-    import.meta.env.VITE_INDEXED_DB_VERSION || 1,
+    import.meta.env.VITE_INDEXED_DB_VERSION || 2,
     {
       formData:
         "uuid, fullName, email, phoneNumber, numberOfFish, address1, address2, city, state, zipcode, occupation, department, species, computedPrice",
       species: "name, price",
+      sets: "id, deployDate, setStatus",
     },
   );
 

--- a/src/mocks/data/mockSets.json
+++ b/src/mocks/data/mockSets.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": 1,
+    "targetSpecies": 110,
+    "deployDate": "2024-04-24T18:25:34Z",
+    "deployTime": "10:25",
+    "deployLat": 56.866667,
+    "deployLong": 162.4,
+    "begGearDepth": 60,
+    "endGearDepth": 60,
+    "setStatus": "Submitted"
+  },
+  {
+    "id": 2,
+    "targetSpecies": 110,
+    "deployDate": "2024-04-24T18:25:34Z",
+    "deployTime": "10:25",
+    "deployLat": 56.866667,
+    "deployLong": 162.4,
+    "begGearDepth": 60,
+    "endGearDepth": 60,
+    "setStatus": "Saved"
+  },
+  {
+    "id": 3,
+    "targetSpecies": 110,
+    "deployDate": "2024-04-24T18:25:34Z",
+    "deployTime": "10:25",
+    "deployLat": 56.866667,
+    "deployLong": 162.4,
+    "begGearDepth": 60,
+    "endGearDepth": 60,
+    "setStatus": "Saved"
+  },
+  {
+    "id": 4,
+    "targetSpecies": 110,
+    "deployDate": "2024-04-24T18:25:34Z",
+    "deployTime": "10:25",
+    "deployLat": 56.866667,
+    "deployLong": 162.4,
+    "begGearDepth": 60,
+    "endGearDepth": 60,
+    "setStatus": "Draft"
+  }
+]

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,9 +1,12 @@
 import { http, HttpResponse } from "msw";
 import { computePriceFromQuantitySpecies } from "../config/form";
 
+import setsJsonData from "./data/mockSets.json";
+
 export const MSW_ENDPOINT = {
   SPECIES: "/species",
   TABLE: "/table",
+  SETS: "/sets",
 };
 
 const data = [
@@ -43,6 +46,11 @@ export const handlers = [
       { status: 200 },
     );
   }),
+
+  http.get(MSW_ENDPOINT.SETS, () => {
+    return HttpResponse.json({ data: setsJsonData }, { status: 200 });
+  }),
+
   // This endpoint simply returns the data that is submitted to from a form
   // In a full stack implementation, there will likely be some logic on the server to handle/store persistent data
   http.post(MSW_ENDPOINT.SPECIES, async ({ request }) => {

--- a/src/pages/CoolForm.jsx
+++ b/src/pages/CoolForm.jsx
@@ -1,0 +1,170 @@
+import React, { useState } from "react";
+import { Alert, Checkbox, FormGroup } from "@trussworks/react-uswds";
+import {
+  TextInput,
+  Radio,
+  Select,
+  Button,
+  Label,
+  ErrorMessage,
+  Toast,
+  ToastStatus,
+} from "../packages/react-components";
+import { useFormState } from "../contexts/FormWrapper.example";
+import { fullNameValidators } from "../utilities";
+import useOfflineStorage from "../hooks/useOfflineStorage.example";
+import { CONSTANTS } from "../config/form";
+import "../styles/theme.css";
+
+const { fullName, numberOfFish, radioOption, species, subSpecies, computedPrice } = CONSTANTS;
+
+/**
+ * React functional component for a demo form. Demonstrates how to construct a form. This should be a child of `FormWrapper`
+ *
+ * @component
+ * @param {Object} props - React component props.
+ * @param {Object} props.asyncFormOptions - Options for asynchronous form elements, helpful for providing default form options that are provided from centralized backend.
+ * @returns {JSX.Element} The JSX element representing the demo form.
+ */
+const CoolForm = ({ asyncFormOptions }) => {
+  const {
+    formData,
+    visibleInputs,
+    handleChange,
+    handleBlur,
+    validationErrors,
+    handleMultiEntrySubmit,
+  } = useFormState();
+  const [toast, setToast] = useState(null);
+
+  return (
+    <>
+      <div className="toast-container">
+        <Toast toast={toast} />
+      </div>
+      <FormGroup error={validationErrors[fullName]}>
+        <Label htmlFor={fullName}>Full Name</Label>
+        {validationErrors[fullName] && <ErrorMessage>{validationErrors[fullName]}</ErrorMessage>}
+        <TextInput
+          id={fullName}
+          name={fullName}
+          type="text"
+          placeholder="Full Name"
+          value={formData[fullName] || ""}
+          aria-invalid={validationErrors[fullName] ? "true" : "false"}
+          validationStatus={validationErrors[fullName] ? "error" : undefined}
+          onChange={handleChange}
+          onBlur={(e) => handleBlur(e, fullNameValidators)}
+          data-testid="inputId"
+        />
+      </FormGroup>
+
+      <Label htmlFor="checkbox">Checkbox Example</Label>
+      <Checkbox id="Oahu" name="islands" value="Oahu" label="Oahu" defaultChecked />
+      <Checkbox id="Kauai" name="islands" value="Kauai" label="Kauai" />
+      <Checkbox id="Mauai" name="islands" value="Mauai" label="Mauai" />
+
+      <Label htmlFor={radioOption}>Have you caught fish today?</Label>
+      <Radio
+        id="option-catch-yes"
+        name={radioOption}
+        label="Yes"
+        value="option-catch-yes"
+        checked={formData[radioOption] === "option-catch-yes"}
+        onChange={handleChange}
+      />
+      <Radio
+        id="option-catch-no"
+        name={radioOption}
+        label="No"
+        value="option-catch-no"
+        checked={formData[radioOption] === "option-catch-no"}
+        onChange={handleChange}
+      />
+
+      <Label htmlFor={numberOfFish}>Number of Fish</Label>
+      <Alert type="info" slim={true}>
+        Example of a linked input. The value of this input is used to compute the price.
+      </Alert>
+      <TextInput
+        id={numberOfFish}
+        // linkedInputId tells computedPrice to update onChange
+        linkedinputids={[computedPrice]}
+        name={numberOfFish}
+        type="number"
+        placeholder="0"
+        value={formData[numberOfFish] || ""}
+        onChange={handleChange}
+      />
+
+      <Label htmlFor={species}>Species</Label>
+      <Alert type="info" slim={true}>
+        The species select input is dependent on data coming from a server. The current
+        implementation is using a mock server.
+      </Alert>
+      <Select
+        // linkedinputids tells computedPrice to update onChange
+        linkedinputids={[computedPrice, subSpecies]}
+        name={species}
+        value={formData[species] || ""}
+        onChange={handleChange}
+      >
+        <option value="">Select Species</option>
+        {asyncFormOptions?.species?.map((option) => (
+          <option key={option} value={option.toLowerCase()}>
+            {option.charAt(0).toUpperCase() + option.slice(1)}
+          </option>
+        ))}
+      </Select>
+      {visibleInputs[subSpecies] && (
+        <>
+          <Label htmlFor={subSpecies}>Sub species</Label>
+          <Alert type="info" slim={true}>
+            Only visible when a species is selected.
+          </Alert>
+          <TextInput
+            id={subSpecies}
+            name={subSpecies}
+            type="text"
+            placeholder="Sub-species"
+            value={formData[subSpecies] || ""}
+            onChange={handleChange}
+          />
+        </>
+      )}
+
+      <Label htmlFor={species}>Computed Price</Label>
+      <Alert type="info" slim={true}>
+        Readonly input. Its value is calculated based on the number of fish and species selected.
+      </Alert>
+      <TextInput
+        readOnly
+        id={computedPrice}
+        name={computedPrice}
+        type="text"
+        placeholder="Computed Price"
+        value={formData[computedPrice] || ""}
+        onChange={handleChange}
+      />
+
+      <div className="grid-row flex-column">
+        <Alert type="info" slim={true}>
+          Button Option 2: Below is an example of a multi-entry button, it sends data to a server.
+          The current implementation is using a mock server.
+        </Alert>
+        <Button
+          role="form-submit"
+          type="submit"
+          onClick={() =>
+            handleMultiEntrySubmit({ numberOfFish: Number(formData.numberOfFish) + 1 })
+          }
+          className="margin-top-10px border-105"
+        >
+          Multi Entry Submit
+        </Button>
+      </div>
+    </>
+  );
+};
+
+export { CoolForm };

--- a/src/pages/SetsTable.jsx
+++ b/src/pages/SetsTable.jsx
@@ -1,0 +1,233 @@
+/**
+ * Component for displaying a demo table.
+ * @returns {React.ReactNode} - The demo table component.
+ */
+
+import { useEffect, useState } from "react";
+import { useTableState } from "../contexts/SetsTableWrapper";
+import { MSW_ENDPOINT } from "../mocks/handlers";
+import RadfishAPIService from "../packages/services/APIService";
+import {
+  Table,
+  TableBody,
+  TableBodyRow,
+  TableHeaderCell,
+  TableHeader,
+  TableHeaderRow,
+  TableBodyCell,
+  Button,
+  TablePaginationNav,
+  TablePaginationPageCount,
+  TablePaginationGoToPage,
+  TablePaginationSelectRowCount,
+  Toast,
+  ToastStatus,
+} from "../packages/react-components";
+import { useNavigate } from "react-router-dom";
+import useOfflineStorage from "../hooks/useOfflineStorage.example";
+import { Alert } from "@trussworks/react-uswds";
+import { COMMON_CONFIG } from "../config/common";
+
+const TOAST_LIFESPAN = 3000;
+const ApiService = new RadfishAPIService("");
+
+const SetsTable = () => {
+  /**
+   * Retrieves table state from the context.
+   * @type {object}
+   * @property {string} tableCaption - Caption for the table.
+   * @property {TableInstance} table - The React Table instance.
+   * @property {Function} setData - Function to set table data. Useful for initializing data from cache or API endpoint
+   */
+  const { tableCaption, table, headerNames, rowModel, setData } = useTableState();
+  const navigate = useNavigate();
+  const [toast, setToast] = useState(null);
+  const { findOfflineData, deleteOfflineData } = useOfflineStorage();
+  // Check if the app is offline
+  // const isOffline = !navigator.onLine;
+
+  /**
+   * Fetches table data from the API service and sets it to the state in TableWrapper context.
+   * Remember that DemoTable needs to be wrapped by a TableWrapper
+   */
+  useEffect(() => {
+    const fetchFormData = async () => {
+      const offlineData = await findOfflineData("sets");
+
+      setData((prevData) => {
+        // Get offline data
+        const offlineDataMapped = offlineData
+          ? offlineData.map((entry) => ({ id: entry.uuid, ...entry, isOffline: true }))
+          : [];
+        // Combine offline data with new data and existing data
+        const combinedData = [...offlineDataMapped, ...prevData];
+        // Remove duplicates
+        const uniqueDataMap = Array.from(
+          new Map(combinedData.map((item) => [item.id, item])).values(),
+        );
+        // Set the state with the unique data
+        return uniqueDataMap;
+      });
+    };
+
+    fetchFormData();
+  }, [setData]);
+
+  /**
+   * handleRowClick gets executed in the onClick handler on TableBodyRow
+   * This can be useful for re-routing to a detail page, or handling other data specific functionality
+   */
+  const handleRowClick = (row) => {
+    // row.original.id should be the id used when generating the form. this can come from MSW or alternatively from IndexDB/localStorage as needed when offline
+    navigate(`/complexform/${row.original.id}`);
+  };
+
+  if (!table) {
+    return null;
+  }
+
+  /**
+   * This is a demo function that simulates the submission of offline data by removing the `isOffline` flag.
+   * In a real application, you should make a POST request with the offline data to your server and then clear
+   * the local storage or any state that holds this offline data.
+   */
+
+  const handleSubmitDraft = async (e, draftData) => {
+    e.stopPropagation();
+    e.preventDefault();
+    try {
+      const { data } = await ApiService.post(MSW_ENDPOINT.SPECIES, { body: draftData });
+      setData((prevData) => {
+        // Remove the submitted drafts based on their IDs
+        const filteredData = prevData.filter(
+          (prevItem) => !data.some((submittedItem) => submittedItem.id === prevItem.id),
+        );
+        // Combine the filtered previous data with the newly updated data from the server
+        return [...filteredData, ...data];
+      });
+      //delete submitted drafts from local storage
+      const idsFromApiResponse = data.map((item) => item.id);
+      deleteOfflineData("formData", idsFromApiResponse);
+      const { status, message } = ToastStatus.SUCCESS;
+      setToast({ status, message });
+    } catch (error) {
+      const { status, message } = ToastStatus.ERROR;
+      setToast({ status, message });
+    } finally {
+      setTimeout(() => {
+        setToast(null);
+      }, TOAST_LIFESPAN);
+    }
+  };
+
+  return (
+    <>
+      <Toast toast={toast} />
+      <br />
+      <div className="margin-left-auto display-flex flex-column flex-align-end width-auto">
+        <Table bordered caption={tableCaption || ""} fullWidth fixed>
+          <TableHeader table={table}>
+            <TableHeaderRow table={table}>
+              {headerNames.map((header) => {
+                return <TableHeaderCell key={header.id} header={header} />;
+              })}
+            </TableHeaderRow>
+          </TableHeader>
+          <TableBody table={table}>
+            {rowModel.rows.map((row) => {
+              const isOfflineData = row.original.isOffline && !row.original.isSubmitted;
+              return (
+                <TableBodyRow
+                  row={row}
+                  onClick={() => handleRowClick(row)}
+                  className={isOfflineData && "bg-gray-10"}
+                  key={row.original.id}
+                  data-testid="table-body-row"
+                >
+                  {row.getVisibleCells().map((cell) => {
+                    const isStatusColumn = cell.column.id === "isOffline";
+                    return (
+                      <TableBodyCell className="radfish-table-body-cell" key={cell.id} cell={cell}>
+                        {isStatusColumn && isOfflineData && (
+                          <Button
+                            onClick={(e) => handleSubmitDraft(e, [row.original])}
+                            className="font-ui-3xs padding-3px margin-left-205"
+                          >
+                            Submit
+                          </Button>
+                        )}
+                      </TableBodyCell>
+                    );
+                  })}
+                </TableBodyRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="grid-container margin-bottom-3">
+        <div className="grid-row display-flex tablet:flex-justify flex-align-center mobile-lg:display-flex flex-justify-center">
+          <div className="width-mobile grid-col-auto display-flex flex-no-wrap">
+            <TablePaginationNav
+              setPageIndex={table.setPageIndex}
+              previousPage={table.previousPage}
+              nextPage={table.nextPage}
+              getCanPreviousPage={table.getCanPreviousPage}
+              getCanNextPage={table.getCanNextPage}
+              getPageCount={table.getPageCount}
+            />
+          </div>
+          <div className="grid-col-auto display-flex flex-wrap flex-align-center margin-y-1">
+            <TablePaginationPageCount
+              pageIndex={table.getState().pagination.pageIndex + 1}
+              getPageCount={table.getPageCount}
+            />
+            <TablePaginationGoToPage
+              pageIndex={table.getState().pagination.pageIndex + 1}
+              setPageIndex={table.setPageIndex}
+            />
+            <TablePaginationSelectRowCount
+              pageSize={table.getState().pagination.pageSize}
+              setPageSize={table.setPageSize}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+function TableInfoAnnotation() {
+  return (
+    <Alert type="info" headingLevel={"h1"} heading="Table Components">
+      Below is an example of a table that's populated by server and locally stored data
+      (localStorage or indexedDB). The table is designed to be used with the `TableWrapper`
+      component, it's built with{" "}
+      <a href={COMMON_CONFIG.reactTableURL} target="_blank" rel="noopener noreferrer">
+        react-table
+      </a>
+      .
+      <br />
+      <br />
+      Offline form data entries or "drafts" are highlighted in grey, and can be submitted to the
+      server using the "submit" button in the "status" column when the application is connected to
+      the internet.
+      <br />
+      <br />
+      <strong>Note:</strong> Annotations are for informational purposes only. In production, you
+      would remove the annotations. Components with annotations above them are optional. You can
+      choose whether or not to use them in your application.
+      <br />
+      <br />
+      <a href={COMMON_CONFIG.docsUrl} target="_blank" rel="noopener noreferrer">
+        <Button type="button">Go To Documentation</Button>
+      </a>
+      <a href={COMMON_CONFIG.storybookURL} target="_blank" rel="noopener noreferrer">
+        <Button type="button">Go To Storybook</Button>
+      </a>
+    </Alert>
+  );
+}
+
+export { SetsTable };


### PR DESCRIPTION
**Findings/Recommendation**

For this exercise, I built 2 examples, one Form (`CoolForm`) and one table (`SetTable`). The latter was done with Jesse and mimicked an application spec shared with him by Chad on the NOAA Alaska team.

There's 3 main takeaways that I got from this exercise:
1. There's a lot of disjointed code "cruft" that we need to cleanup and refine so that the examples we provide are clear, clean and concise. This includes both code and documentation (Notion, README, etc)
2. Getting from initial app boot to that "Aha!" moment with RADFish needs to happen faster
3. A lot of RADFish's value is too implicit. We need to add walkthroughs or similar to make that value explicit 


**Bugs/Hiccups noticed when going through Form building exercise**
**- [Hiccup]** “Submit offline data” button can be removed. It’s not needed or useful to NOAA given the use cases they run into
**- [Hiccup]** Figuring out how to use the `FormWrapper` isn't easy and I was left wondering why we have a "wrapper" that isn't generic
**- [Hiccup]** Without a walkthrough of each example, I had a hard time understanding what was being demonstrated. Perhaps a multi-step walkthrough component? See [Frigade](https://frigade.com/) for example components that do this
**- [Hiccup]** The `FORM_CONFIG` didn't affect my new form. I had a difficult time wrapping my head around the fact that the config was meant to declare visibility/side-effects in one place while components themselves still had to be declared elsewhere
**- [Hiccup]** It would be helpful to guide users in the direction of toggling online/offline mode so that they know what happens when they do that
**- [Bug]** Multi-entry submit button takes me to the Table view



**Bugs/Hiccups noticed when going through Table building exercise**
**- [Bug]** Deprecation message when scaffolding new app. “The CJS build of Vite's Node API is deprecated” when running “npm start”
**- [Bug]** Unused imports lingering around (ie: in Table page). We need to lint these automagically
**- [Bug]** Need to remove API calls from Table component. These should be in the home base sync in the app entry point
**- [Hiccup]** Removing example code runs high risk of breaking when trying to create a new application. Is there a way for us to make it easier to alter the boilerplate code without breaking things?
**- [Hiccup]** Old example using localStorage within App.jsx should be cleaned up
**- [Hiccup]** Hardcoded config of IndexDB store is confusing. There should be an explicit config object instantiated in App.jsx
**- [Hiccup]** We don't have an `ErrorBoundary` setup
**- [Hiccup]** Hard to debug what happens when you need to add a new IndexDB table. Increment version number and add new store to config