### PR TITLE
[RADFISH-139]: Homebase Sync to `MultiStepForm` (Do not merge)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import { TripReportTable } from "./pages/TripReportTable";
 import { TripReportTableClamLobster } from "./pages/TripReportTableClamLobster";
 import useOfflineStorage from "./hooks/useOfflineStorage.example";
 import { HomePage } from "./pages/HomePage";
+import { FormWrapper } from "./contexts/FormWrapper";
+import { ReportForm } from "./pages/ReportForm";
 
 const ApiService = new RadfishAPIService("");
 
@@ -121,6 +123,10 @@ function App() {
     }
   };
 
+  const handleFormSubmit = (data) => {
+    console.log("FORM SUBMIT: ", data);
+  };
+
   return (
     <Router>
       <div className="App">
@@ -139,13 +145,20 @@ function App() {
                 />
               }
             />
-
             <Route
               path="/tripReport"
               element={
                 <TableWrapper>
                   <TripReportTable />
                 </TableWrapper>
+              }
+            />
+            <Route
+              path="/tripReport/:tripReportId/:formId"
+              element={
+                <FormWrapper>
+                  <ReportForm />
+                </FormWrapper>
               }
             />
             <Route

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -154,6 +154,14 @@ function App() {
               }
             />
             <Route
+              path="/tripReport/:tripReportId"
+              element={
+                <FormWrapper>
+                  <ReportForm />
+                </FormWrapper>
+              }
+            />
+            <Route
               path="/tripReport/:tripReportId/:formId"
               element={
                 <FormWrapper>

--- a/src/components/HeaderNav.jsx
+++ b/src/components/HeaderNav.jsx
@@ -4,21 +4,6 @@ import { Header, Navigation } from "../packages/react-components";
 import { version } from "../../package.json";
 import Logo from "../assets/noaa-logo-circle.svg";
 
-/**
- * HeaderNav Component
- * @param children HTML `<a>` tag links, i.e. `<a href="/">Home</a>`
- * @returns Array of `<a>` tags [`<a href="#">linke one</a>`, `<a href="#">linke one</a>`]
- *
- * The `HeaderNav` component can be used to display a navigation header. By default, this component is used within the `Layout` component. It is mobile responsive, and will convert to an expandable navigation menu with a hamburger icon on smaller screens.
- *
- * Example usage:
-    ```<HeaderNav>
-        // add links here
-        <a href="/">Home</a>
-        <a href="/">About</a>
-      </HeaderNav>```
- */
-
 const HeaderNav = ({ children }) => {
   const [expanded, setExpanded] = useState(false);
   const onExpandNavMenuClick = () => setExpanded((prvExpanded) => !prvExpanded);

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,22 +3,6 @@ import { GridContainer } from "@trussworks/react-uswds";
 import HeaderNav from "./HeaderNav";
 import { Link } from "react-router-dom";
 
-/**
- * Layout Component
- * @param children React components
- * @returns React components
- * 
- * The `Layout` should be used as a top-level component, at the root of the application in `App.js`. This component ensures that all pages follow the same style guidelines such as responsiveness, margins, padding, etc.
- * 
- * Example usage:
-    ```<div className="App">
-        <Layout>
-          <Component/>
-          <OtherComponent/>
-        </Layout>
-      </div>```
- */
-
 const Layout = ({ children }) => {
   return (
     <>

--- a/src/components/ReportForm/FormSubmit.jsx
+++ b/src/components/ReportForm/FormSubmit.jsx
@@ -1,0 +1,24 @@
+import { useParams } from "react-router-dom";
+import { Grid } from "@trussworks/react-uswds";
+import { Button } from "../../packages/react-components";
+import useMultiStepForm from "../../hooks/useMultiStepForm";
+
+export const FormSubmit = () => {
+  const { tripReportId } = useParams();
+  const { stepBackward } = useMultiStepForm(tripReportId);
+  return (
+    <Grid className="display-flex flex-justify">
+      <Button
+        type="button"
+        className="margin-top-1"
+        onClick={stepBackward}
+        data-testid="step-backward"
+      >
+        Prev Step
+      </Button>
+      <Button role="form-submit" type="submit">
+        {navigator.onLine ? "Online Submit" : "Offline Submit"}
+      </Button>
+    </Grid>
+  );
+};

--- a/src/components/ReportForm/FormSubmit.jsx
+++ b/src/components/ReportForm/FormSubmit.jsx
@@ -4,8 +4,8 @@ import { Button } from "../../packages/react-components";
 import useMultiStepForm from "../../hooks/useMultiStepForm";
 
 export const FormSubmit = () => {
-  const { tripReportId } = useParams();
-  const { stepBackward } = useMultiStepForm(tripReportId);
+  const { formId } = useParams();
+  const { stepBackward } = useMultiStepForm(formId);
   return (
     <Grid className="display-flex flex-justify">
       <Button

--- a/src/components/ReportForm/FormSubmit.jsx
+++ b/src/components/ReportForm/FormSubmit.jsx
@@ -5,7 +5,7 @@ import useMultiStepForm from "../../hooks/useMultiStepForm";
 
 export const FormSubmit = () => {
   const { formId } = useParams();
-  const { stepBackward } = useMultiStepForm(formId);
+  const { stepBackward, handleSubmit } = useMultiStepForm(formId);
   return (
     <Grid className="display-flex flex-justify">
       <Button
@@ -16,7 +16,7 @@ export const FormSubmit = () => {
       >
         Prev Step
       </Button>
-      <Button role="form-submit" type="submit">
+      <Button role="form-submit" type="submit" onClick={handleSubmit}>
         {navigator.onLine ? "Online Submit" : "Offline Submit"}
       </Button>
     </Grid>

--- a/src/components/ReportForm/StepControl.jsx
+++ b/src/components/ReportForm/StepControl.jsx
@@ -4,8 +4,8 @@ import { Button } from "../../packages/react-components";
 import useMultiStepForm from "../../hooks/useMultiStepForm";
 
 export const StepControl = () => {
-  const { tripReportId } = useParams();
-  const { stepForward, stepBackward } = useMultiStepForm(tripReportId);
+  const { formId } = useParams();
+  const { stepForward, stepBackward } = useMultiStepForm(formId);
   return (
     <Grid className="display-flex flex-justify">
       <Button

--- a/src/components/ReportForm/StepControl.jsx
+++ b/src/components/ReportForm/StepControl.jsx
@@ -1,0 +1,29 @@
+import { useParams } from "react-router-dom";
+import { Grid } from "@trussworks/react-uswds";
+import { Button } from "../../packages/react-components";
+import useMultiStepForm from "../../hooks/useMultiStepForm";
+
+export const StepControl = () => {
+  const { tripReportId } = useParams();
+  const { stepForward, stepBackward } = useMultiStepForm(tripReportId);
+  return (
+    <Grid className="display-flex flex-justify">
+      <Button
+        type="button"
+        className="margin-top-1 margin-right-0 order-last"
+        onClick={stepForward}
+        data-testid="step-forward"
+      >
+        Next Step
+      </Button>
+      <Button
+        type="button"
+        className="margin-top-1"
+        onClick={stepBackward}
+        data-testid="step-backward"
+      >
+        Prev Step
+      </Button>
+    </Grid>
+  );
+};

--- a/src/components/ReportForm/StepFour.jsx
+++ b/src/components/ReportForm/StepFour.jsx
@@ -9,8 +9,8 @@ import { FormSubmit } from "./FormSubmit";
 const { numTrapsInWater, numTrapsHauled, numTrapsPerString, numBuoyLines } = CONSTANTS;
 
 export const StepFour = () => {
-  const { tripReportId } = useParams();
-  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  const { formId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(formId);
   return (
     <FormGroup error={false}>
       <h3>Step 4: Effort Information</h3>

--- a/src/components/ReportForm/StepFour.jsx
+++ b/src/components/ReportForm/StepFour.jsx
@@ -1,0 +1,64 @@
+import { useParams } from "react-router-dom";
+import inputsMetadata from "../../config/InputsMetadata.json";
+import { FormGroup } from "@trussworks/react-uswds";
+import { Label, TextInput } from "../../packages/react-components";
+import { CONSTANTS } from "../../config/form";
+import useMultiStepForm from "../../hooks/useMultiStepForm";
+import { FormSubmit } from "./FormSubmit";
+
+const { numTrapsInWater, numTrapsHauled, numTrapsPerString, numBuoyLines } = CONSTANTS;
+
+export const StepFour = () => {
+  const { tripReportId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  return (
+    <FormGroup error={false}>
+      <h3>Step 4: Effort Information</h3>
+      <Label htmlFor={numTrapsInWater}>
+        {inputsMetadata.fields.effort[0].numTrapsInWater.label[0].en}
+      </Label>
+      <TextInput
+        id={numTrapsInWater}
+        name={numTrapsInWater}
+        type="number"
+        placeholder="0"
+        value={formData[numTrapsInWater] || ""}
+        onChange={handleChange}
+      />
+      <Label htmlFor={numTrapsHauled}>
+        {inputsMetadata.fields.effort[1].numTrapsHauled.label[0].en}
+      </Label>
+      <TextInput
+        id={numTrapsHauled}
+        name={numTrapsHauled}
+        type="number"
+        placeholder="0"
+        value={formData[numTrapsHauled] || ""}
+        onChange={handleChange}
+      />
+      <Label htmlFor={numTrapsPerString}>
+        {inputsMetadata.fields.effort[2].numTrapsPerString.label[0].en}
+      </Label>
+      <TextInput
+        id={numTrapsPerString}
+        name={numTrapsPerString}
+        type="number"
+        placeholder="0"
+        value={formData[numTrapsPerString] || ""}
+        onChange={handleChange}
+      />
+      <Label htmlFor={numBuoyLines}>
+        {inputsMetadata.fields.effort[3].numBuoyLines.label[0].en}
+      </Label>
+      <TextInput
+        id={numBuoyLines}
+        name={numBuoyLines}
+        type="number"
+        placeholder="0"
+        value={formData[numBuoyLines] || ""}
+        onChange={handleChange}
+      />
+      <FormSubmit />
+    </FormGroup>
+  );
+};

--- a/src/components/ReportForm/StepOne.jsx
+++ b/src/components/ReportForm/StepOne.jsx
@@ -1,0 +1,38 @@
+import { useParams } from "react-router-dom";
+import { FormGroup } from "@trussworks/react-uswds";
+import { Label, Select, TextInput } from "../../packages/react-components";
+import { CONSTANTS } from "../../config/form";
+import useMultiStepForm from "../../hooks/useMultiStepForm";
+import { StepControl } from "./StepControl";
+
+const { vesselName, activity } = CONSTANTS;
+
+export const StepOne = ({ activityData }) => {
+  const { tripReportId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  return (
+    <FormGroup error={false}>
+      <h3>Step 1: Basic Information</h3>
+      <Label htmlFor={vesselName}>Vessel</Label>
+      <TextInput
+        id={vesselName}
+        name={vesselName}
+        type="text"
+        placeholder="Vessel Name"
+        value={formData[vesselName] || ""}
+        onChange={handleChange}
+        data-testid="inputId"
+      />
+      <Label htmlFor={activity}>Activity</Label>
+      <Select name={activity} value={formData[activity] || ""} onChange={handleChange}>
+        <option value="">Select Activity</option>
+        {activityData?.map((activity) => (
+          <option key={activity.KEY} value={activity.VALUE}>
+            {activity.VALUE}
+          </option>
+        ))}
+      </Select>
+      <StepControl />
+    </FormGroup>
+  );
+};

--- a/src/components/ReportForm/StepOne.jsx
+++ b/src/components/ReportForm/StepOne.jsx
@@ -8,8 +8,8 @@ import { StepControl } from "./StepControl";
 const { vesselName, activity } = CONSTANTS;
 
 export const StepOne = ({ activityData }) => {
-  const { tripReportId } = useParams();
-  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  const { formId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(formId);
   return (
     <FormGroup error={false}>
       <h3>Step 1: Basic Information</h3>

--- a/src/components/ReportForm/StepThree.jsx
+++ b/src/components/ReportForm/StepThree.jsx
@@ -1,0 +1,71 @@
+import { useParams } from "react-router-dom";
+import inputsMetadata from "../../config/InputsMetadata.json";
+import { FormGroup } from "@trussworks/react-uswds";
+import { Label, TextInput } from "../../packages/react-components";
+import { CONSTANTS } from "../../config/form";
+import useMultiStepForm from "../../hooks/useMultiStepForm";
+import { StepControl } from "./StepControl";
+
+const { trapsPerString, trapsInWater, avgSoakTime, totNrBuoyLines, date_land } = CONSTANTS;
+
+export const StepThree = () => {
+  const { tripReportId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  return (
+    <FormGroup error={false}>
+      <h3>Step 3: Trip Information</h3>
+      <Label htmlFor={trapsPerString}>
+        {inputsMetadata.fields.trip[0].trapsInWater.label[0].en}
+      </Label>
+      <TextInput
+        id={trapsPerString}
+        name={trapsPerString}
+        type="number"
+        placeholder="0"
+        value={formData[trapsPerString] || ""}
+        onChange={handleChange}
+      />
+      <Label htmlFor={trapsInWater}>
+        {inputsMetadata.fields.trip[1].trapsPerString.label[0].en}
+      </Label>
+      <TextInput
+        id={trapsInWater}
+        name={trapsInWater}
+        type="number"
+        placeholder="0"
+        value={formData[trapsInWater] || ""}
+        onChange={handleChange}
+      />
+      <Label htmlFor={avgSoakTime}>{inputsMetadata.fields.trip[3].avgSoakTime.label[0].en}</Label>
+      <TextInput
+        id={avgSoakTime}
+        name={avgSoakTime}
+        type="number"
+        placeholder="0"
+        value={formData[avgSoakTime] || ""}
+        onChange={handleChange}
+      />
+      <Label htmlFor={avgSoakTime}>
+        {inputsMetadata.fields.trip[4].totNrBuoyLines.label[0].en}
+      </Label>
+      <TextInput
+        id={totNrBuoyLines}
+        name={totNrBuoyLines}
+        type="number"
+        placeholder="0"
+        value={formData[totNrBuoyLines] || ""}
+        onChange={handleChange}
+      />
+      <Label htmlFor={avgSoakTime}>Date Landed</Label>
+      <TextInput
+        id={date_land}
+        name={date_land}
+        type="text"
+        placeholder="1/1/2024"
+        value={formData[date_land] || ""}
+        onChange={handleChange}
+      />
+      <StepControl />
+    </FormGroup>
+  );
+};

--- a/src/components/ReportForm/StepThree.jsx
+++ b/src/components/ReportForm/StepThree.jsx
@@ -9,8 +9,8 @@ import { StepControl } from "./StepControl";
 const { trapsPerString, trapsInWater, avgSoakTime, totNrBuoyLines, date_land } = CONSTANTS;
 
 export const StepThree = () => {
-  const { tripReportId } = useParams();
-  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  const { formId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(formId);
   return (
     <FormGroup error={false}>
       <h3>Step 3: Trip Information</h3>

--- a/src/components/ReportForm/StepTwo.jsx
+++ b/src/components/ReportForm/StepTwo.jsx
@@ -8,8 +8,8 @@ import { StepControl } from "./StepControl";
 const { species } = CONSTANTS;
 
 export const StepTwo = ({ speciesData }) => {
-  const { tripReportId } = useParams();
-  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  const { formId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(formId);
   return (
     <FormGroup error={false}>
       <h3>Step 2: Catch Information</h3>

--- a/src/components/ReportForm/StepTwo.jsx
+++ b/src/components/ReportForm/StepTwo.jsx
@@ -1,0 +1,29 @@
+import { useParams } from "react-router-dom";
+import { FormGroup } from "@trussworks/react-uswds";
+import { Label, Select } from "../../packages/react-components";
+import { CONSTANTS } from "../../config/form";
+import useMultiStepForm from "../../hooks/useMultiStepForm";
+import { StepControl } from "./StepControl";
+
+const { species } = CONSTANTS;
+
+export const StepTwo = ({ speciesData }) => {
+  const { tripReportId } = useParams();
+  const { formData, handleChange } = useMultiStepForm(tripReportId);
+  return (
+    <FormGroup error={false}>
+      <h3>Step 2: Catch Information</h3>
+      <Label htmlFor={species}>Species</Label>
+      <Select name={species} value={formData[species] || ""} onChange={handleChange}>
+        <option value="">Select Species</option>
+
+        {speciesData?.map((species) => (
+          <option key={species.SPPCODE} value={species.SPPNAME}>
+            {species.SPPNAME}
+          </option>
+        ))}
+      </Select>
+      <StepControl />
+    </FormGroup>
+  );
+};

--- a/src/config/form.js
+++ b/src/config/form.js
@@ -1,0 +1,176 @@
+const CONSTANTS = {
+  vesselName: "vesselName",
+  activity: "activity",
+  species: "species",
+  trapsInWater: "trapsInWater",
+  trapsPerString: "trapsPerString",
+  stringsHauled: "stringsHauled",
+  avgSoakTime: "avgSoakTime",
+  totNrBuoyLines: "totNrBuoyLines",
+  date_lan: "date_lan",
+  numTrapsInWater: "numTrapsInWater",
+  numTrapsHauled: "numTrapsHauled",
+  numTrapsPerString: "numTrapsPerString",
+  numBuoyLines: "numBuoyLines",
+};
+
+const handleSubSpeciesVisibility = (args, formData) => {
+  for (let arg of args) {
+    if (!formData[arg]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const handleNicknameVisibility = (args, formData) => {
+  let data = args[0];
+  if (!formData[data]) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+const handleCountryVisibility = (args, formData) => {
+  let data = args[0];
+  if (!formData[data]) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+const computePriceFromQuantitySpecies = (values) => {
+  const speciesPriceMap = {
+    grouper: 25.0,
+    salmon: 58.0,
+    marlin: 100.0,
+    mahimahi: 44.0,
+  };
+
+  let computedPrice = parseInt(values[0] || 0) * parseInt(speciesPriceMap[values[1]] || 0);
+  return computedPrice.toString();
+};
+
+const FORM_CONFIG = {
+  [CONSTANTS.vesselName]: {
+    visibility: null,
+    computed: null,
+    validation: null,
+  },
+  [CONSTANTS.activity]: {
+    visibility: null,
+    computed: null,
+    validateion: null,
+  },
+  [CONSTANTS.species]: {
+    visibility: null,
+    computed: null,
+    validation: null,
+  },
+  //   [CONSTANTS.nickname]: {
+  //     visibility: {
+  //       callback: handleNicknameVisibility,
+  //       args: [CONSTANTS.fullName],
+  //       visibleOnMount: false,
+  //     },
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.email]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.phoneNumber]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.country]: {
+  //     visibility: {
+  //       callback: handleCountryVisibility,
+  //       args: [CONSTANTS.phoneNumber],
+  //       visibleOnMount: false,
+  //     },
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.numberOfFish]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.addressLine1]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.radioOption]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.addressLine2]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.city]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.state]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.zipcode]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.occupation]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.department]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.species]: {
+  //     visibility: null,
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.subSpecies]: {
+  //     visibility: {
+  //       callback: handleSubSpeciesVisibility,
+  //       args: [CONSTANTS.species],
+  //       visibleOnMount: false,
+  //     },
+  //     computed: null,
+  //     validation: null,
+  //   },
+  //   [CONSTANTS.computedPrice]: {
+  //     visibility: null,
+  //     computed: {
+  //       callback: computePriceFromQuantitySpecies,
+  //       args: [CONSTANTS.numberOfFish, CONSTANTS.species],
+  //     },
+  //     validation: null,
+  //   },
+};
+
+export {
+  FORM_CONFIG,
+  CONSTANTS,
+  handleSubSpeciesVisibility,
+  handleNicknameVisibility,
+  handleCountryVisibility,
+  computePriceFromQuantitySpecies,
+};

--- a/src/contexts/FormWrapper.jsx
+++ b/src/contexts/FormWrapper.jsx
@@ -1,0 +1,209 @@
+/**
+ * Manages state for any child Radfish form.
+ * This context should wrap the RadfisForm component and will manage it's state related to input fields, input validations, and form submissions
+ * This context provider is meant to be extensible and modular. You can use this anywhere in your app to wrap a form to manage the specific form's state
+ */
+
+import React, { createContext, useState, useCallback, useEffect } from "react";
+import { useNavigate, useSearchParams, useParams } from "react-router-dom";
+import { Alert } from "@trussworks/react-uswds";
+import { Form, Button } from "../packages/react-components";
+import { FORM_CONFIG } from "../config/form";
+import RadfishAPIService from "../packages/services/APIService";
+import useOfflineStorage from "../hooks/useOfflineStorage.example";
+// import { COMMON_CONFIG } from "../config/common";
+
+const FormContext = createContext();
+
+const ApiService = new RadfishAPIService("");
+/**
+ * Higher-order component providing form state and functionality.
+ *
+ * @component
+ * @param {Object} props - React component props.
+ * @param {Function} props.onSubmit - Callback function to handle form submission.
+ * @returns {JSX.Element} The JSX element representing the form wrapper.
+ */
+export const FormWrapper = ({ children, onSubmit }) => {
+  const [formData, setFormData] = useState({});
+  const [visibleInputs, setVisibleInputs] = useState(() =>
+    Object.fromEntries(
+      Object.entries(FORM_CONFIG).map(([key, config]) => [key, config.visibility?.visibleOnMount]),
+    ),
+  );
+  const [validationErrors, setValidationErrors] = useState({});
+  const navigate = useNavigate();
+  const params = useParams();
+  const [searchParams] = useSearchParams();
+  const { findOfflineData } = useOfflineStorage();
+
+  /**
+   * Handles the submission of multiple entries by updating the URL with query parameters.
+   *
+   * @function
+   * @param {Object} params - Query parameters for multi-entry submission.
+   */
+  const handleMultiEntrySubmit = (params) => {
+    const queryString = new URLSearchParams(params).toString();
+    navigate(`/?${queryString}`);
+  };
+
+  /**
+   * useEffect hook to update form data based on URL search parameters. Useful for multi step forms
+   *
+   * @function
+   */
+  useEffect(() => {
+    const newFormData = {};
+    let hasNewData = false;
+
+    for (let [key, value] of searchParams.entries()) {
+      newFormData[key] = value;
+      hasNewData = true;
+    }
+
+    if (hasNewData) {
+      setFormData((prev) => ({ ...prev, ...newFormData }));
+    }
+  }, [searchParams]);
+
+  // if id exists, query data from server with that id
+  useEffect(() => {
+    if (params.id) {
+      const paramFormData = async () => {
+        const { data } = await ApiService.get(`/form/${params.id}`);
+
+        if (data) {
+          setFormData(data);
+        } else {
+          const cachedData = await findOfflineData("formData", { uuid: params.id });
+          if (cachedData) {
+            setFormData(cachedData[0]);
+          }
+        }
+      };
+      paramFormData();
+    }
+  }, [params]);
+
+  const validateInputCallback = useCallback((name, value, validators) => {
+    return handleInputValidationLogic(name, value, validators);
+  }, []);
+
+  const handleComputedValuesCallback = useCallback((inputIds, formData) => {
+    handleComputedValuesLogic(inputIds, formData, FORM_CONFIG);
+  }, []);
+
+  const handleInputVisibilityCallback = useCallback((inputIds, formData) => {
+    const inputVisibility = handleInputVisibilityLogic(inputIds, formData, FORM_CONFIG);
+    setVisibleInputs(inputVisibility);
+  }, []);
+
+  const handleChange = useCallback(
+    (event) => {
+      const { name, value } = event.target;
+      const linkedinputids = event.target.getAttribute("linkedinputids")?.split(",");
+      // if field being updated has a linked field that needs to be computed, update state after computing linked fields
+      // else just return updatedForm without needing to linked computedValues
+      setFormData((prev) => {
+        const updatedForm = { ...prev, [name]: value };
+        if (linkedinputids) {
+          const updatedComputedForm =
+            handleComputedValuesCallback(linkedinputids, updatedForm) || updatedForm;
+          handleInputVisibilityCallback(linkedinputids, updatedComputedForm);
+          return updatedComputedForm;
+        } else {
+          return updatedForm;
+        }
+      });
+    },
+    [handleComputedValuesCallback, handleInputVisibilityCallback],
+  ); // Include 'handleComputedValues' in the dependency array
+
+  const handleBlur = useCallback(
+    (event, validators) => {
+      const { name, value } = event.target;
+      setValidationErrors((prev) => ({
+        ...prev,
+        ...validateInputCallback(name, value, validators),
+      }));
+    },
+    [validateInputCallback],
+  );
+
+  const handleSubmit = (data) => {
+    console.log("SUBMIT: ", data);
+  };
+
+  const contextValue = {
+    formData,
+    visibleInputs,
+    setFormData,
+    handleChange,
+    handleBlur,
+    validationErrors,
+    handleMultiEntrySubmit,
+    searchParams,
+  };
+
+  return (
+    <FormContext.Provider value={contextValue}>
+      <Form
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSubmit(formData);
+        }}
+      >
+        {children}
+      </Form>
+    </FormContext.Provider>
+  );
+};
+
+export const useFormState = () => {
+  const context = React.useContext(FormContext);
+  if (!context) {
+    throw new Error("useFormState must be used within a FormWrapper");
+  }
+  return context;
+};
+
+export const handleComputedValuesLogic = (inputIds, formData, FORM_CONFIG) => {
+  for (let inputId of inputIds) {
+    const computedCallback = FORM_CONFIG[inputId]?.computed?.callback;
+    if (computedCallback) {
+      const args = FORM_CONFIG[inputId].computed.args.map((arg) => formData[arg]);
+      const computedValue = computedCallback(args);
+      formData[inputId] = computedValue;
+    }
+  }
+};
+
+export const handleInputVisibilityLogic = (inputIds, formData, FORM_CONFIG) => {
+  const inputVisibility = {};
+
+  inputIds.forEach((inputId) => {
+    const visibilityCallback = FORM_CONFIG[inputId]?.visibility?.callback;
+    if (visibilityCallback) {
+      const args = FORM_CONFIG[inputId].visibility.args;
+      let result = visibilityCallback(args, formData);
+      inputVisibility[inputId] = result;
+      if (result === false) {
+        formData[inputId] = ""; // Update the form data directly
+      }
+    }
+  });
+
+  return inputVisibility;
+};
+
+export const handleInputValidationLogic = (name, value, validators) => {
+  if (validators && validators.length > 0) {
+    for (let validator of validators) {
+      if (!validator.test(value)) {
+        return { [name]: validator.message };
+      }
+    }
+  }
+  return { [name]: null };
+};

--- a/src/contexts/FormWrapper.jsx
+++ b/src/contexts/FormWrapper.jsx
@@ -1,29 +1,13 @@
-/**
- * Manages state for any child Radfish form.
- * This context should wrap the RadfisForm component and will manage it's state related to input fields, input validations, and form submissions
- * This context provider is meant to be extensible and modular. You can use this anywhere in your app to wrap a form to manage the specific form's state
- */
-
 import React, { createContext, useState, useCallback, useEffect } from "react";
 import { useNavigate, useSearchParams, useParams } from "react-router-dom";
-import { Alert } from "@trussworks/react-uswds";
-import { Form, Button } from "../packages/react-components";
-import { CONSTANTS, FORM_CONFIG } from "../config/form";
+import { Form } from "../packages/react-components";
+import { FORM_CONFIG } from "../config/form";
 import RadfishAPIService from "../packages/services/APIService";
 import useOfflineStorage from "../hooks/useOfflineStorage.example";
-// import { COMMON_CONFIG } from "../config/common";
 
 const FormContext = createContext();
-
 const ApiService = new RadfishAPIService("");
-/**
- * Higher-order component providing form state and functionality.
- *
- * @component
- * @param {Object} props - React component props.
- * @param {Function} props.onSubmit - Callback function to handle form submission.
- * @returns {JSX.Element} The JSX element representing the form wrapper.
- */
+
 export const FormWrapper = ({ children, onSubmit }) => {
   const [formData, setFormData] = useState();
   const [visibleInputs, setVisibleInputs] = useState(() =>
@@ -37,22 +21,11 @@ export const FormWrapper = ({ children, onSubmit }) => {
   const [searchParams] = useSearchParams();
   const { findOfflineData } = useOfflineStorage();
 
-  /**
-   * Handles the submission of multiple entries by updating the URL with query parameters.
-   *
-   * @function
-   * @param {Object} params - Query parameters for multi-entry submission.
-   */
   const handleMultiEntrySubmit = (params) => {
     const queryString = new URLSearchParams(params).toString();
     navigate(`/?${queryString}`);
   };
 
-  /**
-   * useEffect hook to update form data based on URL search parameters. Useful for multi step forms
-   *
-   * @function
-   */
   useEffect(() => {
     const newFormData = {};
     let hasNewData = false;
@@ -103,8 +76,6 @@ export const FormWrapper = ({ children, onSubmit }) => {
     (event) => {
       const { name, value } = event.target;
       const linkedinputids = event.target.getAttribute("linkedinputids")?.split(",");
-      // if field being updated has a linked field that needs to be computed, update state after computing linked fields
-      // else just return updatedForm without needing to linked computedValues
       setFormData((prev) => {
         const updatedForm = { ...prev, [name]: value };
         if (linkedinputids) {
@@ -118,7 +89,7 @@ export const FormWrapper = ({ children, onSubmit }) => {
       });
     },
     [handleComputedValuesCallback, handleInputVisibilityCallback],
-  ); // Include 'handleComputedValues' in the dependency array
+  );
 
   const handleBlur = useCallback(
     (event, validators) => {
@@ -130,10 +101,6 @@ export const FormWrapper = ({ children, onSubmit }) => {
     },
     [validateInputCallback],
   );
-
-  const handleSubmit = (data) => {
-    console.log("SUBMIT: ", data);
-  };
 
   const contextValue = {
     formData,
@@ -151,7 +118,6 @@ export const FormWrapper = ({ children, onSubmit }) => {
       <Form
         onSubmit={(event) => {
           event.preventDefault();
-          handleSubmit(formData);
         }}
       >
         {children}

--- a/src/contexts/FormWrapper.jsx
+++ b/src/contexts/FormWrapper.jsx
@@ -8,7 +8,7 @@ import React, { createContext, useState, useCallback, useEffect } from "react";
 import { useNavigate, useSearchParams, useParams } from "react-router-dom";
 import { Alert } from "@trussworks/react-uswds";
 import { Form, Button } from "../packages/react-components";
-import { FORM_CONFIG } from "../config/form";
+import { CONSTANTS, FORM_CONFIG } from "../config/form";
 import RadfishAPIService from "../packages/services/APIService";
 import useOfflineStorage from "../hooks/useOfflineStorage.example";
 // import { COMMON_CONFIG } from "../config/common";
@@ -25,7 +25,7 @@ const ApiService = new RadfishAPIService("");
  * @returns {JSX.Element} The JSX element representing the form wrapper.
  */
 export const FormWrapper = ({ children, onSubmit }) => {
-  const [formData, setFormData] = useState({});
+  const [formData, setFormData] = useState();
   const [visibleInputs, setVisibleInputs] = useState(() =>
     Object.fromEntries(
       Object.entries(FORM_CONFIG).map(([key, config]) => [key, config.visibility?.visibleOnMount]),

--- a/src/hooks/useMultiStepForm.js
+++ b/src/hooks/useMultiStepForm.js
@@ -1,0 +1,75 @@
+import useOfflineStorage from "./useOfflineStorage.example";
+import { useFormState } from "../contexts/FormWrapper";
+
+const TOTAL_STEPS = 4;
+
+function useMultiStepForm(uuid) {
+  const {
+    formData,
+    visibleInputs,
+    setFormData,
+    handleChange,
+    handleBlur,
+    validationErrors,
+    handleMultiEntrySubmit,
+  } = useFormState();
+  const { createOfflineData, updateOfflineData } = useOfflineStorage();
+
+  async function init() {
+    const uuid = await createOfflineData("formData", {
+      vesselName: "vesselName",
+      activity: "activity",
+      species: "species",
+      trapsInWater: "trapsInWater",
+      trapsPerString: "trapsPerString",
+      stringsHauled: "stringsHauled",
+      avgSoakTime: "avgSoakTime",
+      totNrBuoyLines: "totNrBuoyLines",
+      date_lan: "date_lan",
+      numTrapsInWater: "numTrapsInWater",
+      numTrapsHauled: "numTrapsHauled",
+      numTrapsPerString: "numTrapsPerString",
+      numBuoyLines: "numBuoyLines",
+      // currentStep: 1,
+    });
+    setFormData({ ...formData, currentStep: 1, totalSteps: TOTAL_STEPS });
+    return uuid;
+  }
+
+  function stepForward() {
+    if (formData.currentStep < TOTAL_STEPS) {
+      const nextStep = formData.currentStep + 1;
+      setFormData({ ...formData, currentStep: nextStep });
+      updateOfflineData("formData", [{ ...formData, uuid, currentStep: nextStep }]);
+    }
+  }
+
+  function stepBackward() {
+    if (formData.currentStep > 1) {
+      const prevStep = formData.currentStep - 1;
+      setFormData({ ...formData, currentStep: prevStep });
+      updateOfflineData("formData", [{ ...formData, uuid, currentStep: prevStep }]);
+    }
+  }
+
+  function handleSubmit() {
+    console.log("handleSubmit: ", formData);
+  }
+
+  return {
+    init,
+    stepForward,
+    stepBackward,
+    handleSubmit,
+    // below are composed useFormState values
+    formData,
+    visibleInputs,
+    setFormData,
+    handleChange,
+    handleBlur,
+    validationErrors,
+    handleMultiEntrySubmit,
+  };
+}
+
+export default useMultiStepForm;

--- a/src/hooks/useMultiStepForm.js
+++ b/src/hooks/useMultiStepForm.js
@@ -1,7 +1,7 @@
 import useOfflineStorage from "./useOfflineStorage.example";
 import { useFormState } from "../contexts/FormWrapper";
 
-const TOTAL_STEPS = 4;
+export const TOTAL_STEPS = 4;
 
 function useMultiStepForm(uuid) {
   const {
@@ -17,20 +17,7 @@ function useMultiStepForm(uuid) {
 
   async function init() {
     const uuid = await createOfflineData("formData", {
-      vesselName: "vesselName",
-      activity: "activity",
-      species: "species",
-      trapsInWater: "trapsInWater",
-      trapsPerString: "trapsPerString",
-      stringsHauled: "stringsHauled",
-      avgSoakTime: "avgSoakTime",
-      totNrBuoyLines: "totNrBuoyLines",
-      date_lan: "date_lan",
-      numTrapsInWater: "numTrapsInWater",
-      numTrapsHauled: "numTrapsHauled",
-      numTrapsPerString: "numTrapsPerString",
-      numBuoyLines: "numBuoyLines",
-      // currentStep: 1,
+      currentStep: 1,
     });
     setFormData({ ...formData, currentStep: 1, totalSteps: TOTAL_STEPS });
     return uuid;

--- a/src/hooks/useMultiStepForm.js
+++ b/src/hooks/useMultiStepForm.js
@@ -18,6 +18,7 @@ function useMultiStepForm(uuid) {
   async function init() {
     const uuid = await createOfflineData("formData", {
       currentStep: 1,
+      isDraft: true,
     });
     setFormData({ ...formData, currentStep: 1, totalSteps: TOTAL_STEPS });
     return uuid;
@@ -40,20 +41,24 @@ function useMultiStepForm(uuid) {
   }
 
   function handleSubmit() {
-    console.log("handleSubmit: ", formData);
+    if (navigator.onLine) {
+      updateOfflineData("formData", [{ ...formData, uuid, isDraft: false, offlineSubmit: false }]);
+    } else {
+      updateOfflineData("formData", [{ ...formData, uuid, isDraft: false, offlineSubmit: true }]);
+    }
   }
 
   return {
     init,
     stepForward,
     stepBackward,
-    handleSubmit,
     // below are composed useFormState values
     formData,
     visibleInputs,
     setFormData,
     handleChange,
     handleBlur,
+    handleSubmit,
     validationErrors,
     handleMultiEntrySubmit,
   };

--- a/src/hooks/useOfflineStorage.example.js
+++ b/src/hooks/useOfflineStorage.example.js
@@ -10,6 +10,8 @@ function useOfflineStorage() {
       activityData: "KEY, VALUE",
       speciesData: "SPPSYN, SPPCODE, SPPNAME, ITIS",
       tripTypesData: "KEY, VALUE",
+      formData:
+        "uuid, vesselName, activity, species, trapsInWater, trapsPerString, stringsHauled, avgSoakTime, totNrBuoyLines, date_lan, numTrapsInWater, numTrapsHauled, numTrapsPerString, numBuoyLines",
     },
   );
 

--- a/src/pages/ReportForm.jsx
+++ b/src/pages/ReportForm.jsx
@@ -1,0 +1,220 @@
+import "../styles/theme.css";
+import inputsMetadata from "../config/InputsMetadata.json";
+import React, { useState, useEffect } from "react";
+import { FormGroup } from "@trussworks/react-uswds";
+import { TextInput, Select, Button, Label } from "../packages/react-components";
+import { useFormState } from "../contexts/FormWrapper";
+import { CONSTANTS } from "../config/form";
+import useOfflineStorage from "../hooks/useOfflineStorage.example";
+import { useParams } from "react-router-dom";
+
+const {
+  vesselName,
+  activity,
+  species,
+  trapsInWater,
+  trapsPerString,
+  avgSoakTime,
+  totNrBuoyLines,
+  date_land,
+  numTrapsInWater,
+  numTrapsHauled,
+  numTrapsPerString,
+  numBuoyLines,
+} = CONSTANTS;
+
+const ReportForm = () => {
+  const { findOfflineData } = useOfflineStorage();
+  const { formData, handleChange } = useFormState();
+  const { tripReportId } = useParams();
+
+  const [reportType, setReportType] = useState("");
+  const [tripType, setTripType] = useState("");
+  const [activityData, setActivityData] = useState([]);
+  const [speciesData, setSpeciesData] = useState([]);
+
+  useEffect(() => {
+    const queryFormData = async () => {
+      const [report] = await findOfflineData("offlineTripReportData", {
+        KEY: parseInt(tripReportId),
+      });
+      const [tripType] = await findOfflineData("tripTypesData", {
+        KEY: parseInt(report.TRIP_TYPE),
+      });
+      const activityData = await findOfflineData("activityData");
+      const speciesData = await findOfflineData("speciesData");
+
+      setReportType(report.VALUE);
+      setTripType(tripType.VALUE);
+      setActivityData(activityData);
+      setSpeciesData(speciesData);
+    };
+    queryFormData();
+  }, []);
+
+  return (
+    <>
+      <h1>{reportType} Report Form</h1>
+      <p>Trip Type: {tripType}</p>
+
+      <h3>Step 1: Basic Information</h3>
+      <FormGroup error={false}>
+        <Label htmlFor={vesselName}>Vessel</Label>
+        <TextInput
+          id={vesselName}
+          name={vesselName}
+          type="text"
+          placeholder="Vessel Name"
+          value={formData[vesselName] || ""}
+          onChange={handleChange}
+          data-testid="inputId"
+        />
+        <Label htmlFor={activity}>Activity</Label>
+        <Select name={activity} value={formData[activity] || ""} onChange={handleChange}>
+          <option value="">Select Activity</option>
+          {activityData?.map((activity) => (
+            <option key={activity.KEY} value={activity.VALUE}>
+              {activity.VALUE}
+            </option>
+          ))}
+        </Select>
+      </FormGroup>
+
+      <h3>Step 2: Catch Information</h3>
+      <FormGroup error={false}>
+        <Label htmlFor={species}>Species</Label>
+        <Select name={species} value={formData[species] || ""} onChange={handleChange}>
+          <option value="">Select Species</option>
+
+          {speciesData?.map((species) => (
+            <option key={species.SPPCODE} value={species.SPPNAME}>
+              {species.SPPNAME}
+            </option>
+          ))}
+        </Select>
+      </FormGroup>
+
+      <h3>Step 3: Trip Information</h3>
+      <FormGroup error={false}>
+        <Label htmlFor={trapsPerString}>
+          {inputsMetadata.fields.trip[0].trapsInWater.label[0].en}
+        </Label>
+        <TextInput
+          id={trapsPerString}
+          name={trapsPerString}
+          type="number"
+          placeholder="0"
+          value={formData[trapsPerString] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={trapsInWater}>
+          {inputsMetadata.fields.trip[1].trapsPerString.label[0].en}
+        </Label>
+        <TextInput
+          id={trapsInWater}
+          name={trapsInWater}
+          type="number"
+          placeholder="0"
+          value={formData[trapsInWater] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={trapsPerString}>
+          {inputsMetadata.fields.trip[2].stringsHauled.label[0].en}
+        </Label>
+        <TextInput
+          id={trapsPerString}
+          name={trapsPerString}
+          type="number"
+          placeholder="0"
+          value={formData[trapsPerString] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={avgSoakTime}>{inputsMetadata.fields.trip[3].avgSoakTime.label[0].en}</Label>
+        <TextInput
+          id={avgSoakTime}
+          name={avgSoakTime}
+          type="number"
+          placeholder="0"
+          value={formData[avgSoakTime] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={avgSoakTime}>
+          {inputsMetadata.fields.trip[4].totNrBuoyLines.label[0].en}
+        </Label>
+        <TextInput
+          id={totNrBuoyLines}
+          name={totNrBuoyLines}
+          type="number"
+          placeholder="0"
+          value={formData[totNrBuoyLines] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={avgSoakTime}>Date Landed</Label>
+        <TextInput
+          id={date_land}
+          name={date_land}
+          type="text"
+          placeholder="1/1/2024"
+          value={formData[date_land] || ""}
+          onChange={handleChange}
+        />
+      </FormGroup>
+
+      <h3>Step 4: Effort Information</h3>
+      <FormGroup error={false}>
+        <Label htmlFor={numTrapsInWater}>
+          {inputsMetadata.fields.effort[0].numTrapsInWater.label[0].en}
+        </Label>
+        <TextInput
+          id={numTrapsInWater}
+          name={numTrapsInWater}
+          type="number"
+          placeholder="0"
+          value={formData[numTrapsInWater] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={numTrapsHauled}>
+          {inputsMetadata.fields.effort[1].numTrapsHauled.label[0].en}
+        </Label>
+        <TextInput
+          id={numTrapsHauled}
+          name={numTrapsHauled}
+          type="number"
+          placeholder="0"
+          value={formData[numTrapsHauled] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={numTrapsPerString}>
+          {inputsMetadata.fields.effort[2].numTrapsPerString.label[0].en}
+        </Label>
+        <TextInput
+          id={numTrapsPerString}
+          name={numTrapsPerString}
+          type="number"
+          placeholder="0"
+          value={formData[numTrapsPerString] || ""}
+          onChange={handleChange}
+        />
+        <Label htmlFor={numBuoyLines}>
+          {inputsMetadata.fields.effort[3].numBuoyLines.label[0].en}
+        </Label>
+        <TextInput
+          id={numBuoyLines}
+          name={numBuoyLines}
+          type="number"
+          placeholder="0"
+          value={formData[numBuoyLines] || ""}
+          onChange={handleChange}
+        />
+      </FormGroup>
+
+      <div className="grid-row flex-column">
+        <Button role="form-submit" type="submit">
+          {navigator.onLine ? "Online Submit" : "Offline Submit"}
+        </Button>
+      </div>
+    </>
+  );
+};
+
+export { ReportForm };

--- a/src/pages/ReportForm.jsx
+++ b/src/pages/ReportForm.jsx
@@ -62,24 +62,20 @@ const ReportForm = () => {
     navigate(`/tripReport/${tripReportId}/${uuid}`);
   };
 
-  if (!formData || !reportType || !tripType) {
-    return null;
-  }
-
   return (
     <>
       <h1>{reportType} Report Form</h1>
       <p>Trip Type: {tripType}</p>
 
-      {!formData.currentStep && (
+      {!formData?.currentStep && (
         <Button type="button" onClick={initializeMultistepForm}>
           Initialize Report Form
         </Button>
       )}
-      {formData.currentStep === 1 && <StepOne activityData={activityData} />}
-      {formData.currentStep === 2 && <StepTwo speciesData={speciesData} />}
-      {formData.currentStep === 3 && <StepThree />}
-      {formData.currentStep === 4 && <StepFour />}
+      {formData?.currentStep === 1 && <StepOne activityData={activityData} />}
+      {formData?.currentStep === 2 && <StepTwo speciesData={speciesData} />}
+      {formData?.currentStep === 3 && <StepThree />}
+      {formData?.currentStep === 4 && <StepFour />}
     </>
   );
 };

--- a/src/pages/ReportForm.jsx
+++ b/src/pages/ReportForm.jsx
@@ -1,32 +1,20 @@
 import "../styles/theme.css";
-import inputsMetadata from "../config/InputsMetadata.json";
 import React, { useState, useEffect } from "react";
-import { FormGroup } from "@trussworks/react-uswds";
-import { TextInput, Select, Button, Label } from "../packages/react-components";
-import { useFormState } from "../contexts/FormWrapper";
-import { CONSTANTS } from "../config/form";
+import { useNavigate } from "react-router-dom";
+import { Button } from "../packages/react-components";
 import useOfflineStorage from "../hooks/useOfflineStorage.example";
 import { useParams } from "react-router-dom";
-
-const {
-  vesselName,
-  activity,
-  species,
-  trapsInWater,
-  trapsPerString,
-  avgSoakTime,
-  totNrBuoyLines,
-  date_land,
-  numTrapsInWater,
-  numTrapsHauled,
-  numTrapsPerString,
-  numBuoyLines,
-} = CONSTANTS;
+import useMultiStepForm from "../hooks/useMultiStepForm";
+import { StepOne } from "../components/ReportForm/StepOne";
+import { StepTwo } from "../components/ReportForm/StepTwo";
+import { StepThree } from "../components/ReportForm/StepThree";
+import { StepFour } from "../components/ReportForm/StepFour";
 
 const ReportForm = () => {
   const { findOfflineData } = useOfflineStorage();
-  const { formData, handleChange } = useFormState();
   const { tripReportId } = useParams();
+  const navigate = useNavigate();
+  const { init, formData } = useMultiStepForm(tripReportId);
 
   const [reportType, setReportType] = useState("");
   const [tripType, setTripType] = useState("");
@@ -52,167 +40,25 @@ const ReportForm = () => {
     queryFormData();
   }, []);
 
+  const initializeMultistepForm = async () => {
+    const uuid = await init();
+    navigate(`/tripReport/${tripReportId}/${uuid}`);
+  };
+
   return (
     <>
       <h1>{reportType} Report Form</h1>
       <p>Trip Type: {tripType}</p>
 
-      <h3>Step 1: Basic Information</h3>
-      <FormGroup error={false}>
-        <Label htmlFor={vesselName}>Vessel</Label>
-        <TextInput
-          id={vesselName}
-          name={vesselName}
-          type="text"
-          placeholder="Vessel Name"
-          value={formData[vesselName] || ""}
-          onChange={handleChange}
-          data-testid="inputId"
-        />
-        <Label htmlFor={activity}>Activity</Label>
-        <Select name={activity} value={formData[activity] || ""} onChange={handleChange}>
-          <option value="">Select Activity</option>
-          {activityData?.map((activity) => (
-            <option key={activity.KEY} value={activity.VALUE}>
-              {activity.VALUE}
-            </option>
-          ))}
-        </Select>
-      </FormGroup>
-
-      <h3>Step 2: Catch Information</h3>
-      <FormGroup error={false}>
-        <Label htmlFor={species}>Species</Label>
-        <Select name={species} value={formData[species] || ""} onChange={handleChange}>
-          <option value="">Select Species</option>
-
-          {speciesData?.map((species) => (
-            <option key={species.SPPCODE} value={species.SPPNAME}>
-              {species.SPPNAME}
-            </option>
-          ))}
-        </Select>
-      </FormGroup>
-
-      <h3>Step 3: Trip Information</h3>
-      <FormGroup error={false}>
-        <Label htmlFor={trapsPerString}>
-          {inputsMetadata.fields.trip[0].trapsInWater.label[0].en}
-        </Label>
-        <TextInput
-          id={trapsPerString}
-          name={trapsPerString}
-          type="number"
-          placeholder="0"
-          value={formData[trapsPerString] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={trapsInWater}>
-          {inputsMetadata.fields.trip[1].trapsPerString.label[0].en}
-        </Label>
-        <TextInput
-          id={trapsInWater}
-          name={trapsInWater}
-          type="number"
-          placeholder="0"
-          value={formData[trapsInWater] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={trapsPerString}>
-          {inputsMetadata.fields.trip[2].stringsHauled.label[0].en}
-        </Label>
-        <TextInput
-          id={trapsPerString}
-          name={trapsPerString}
-          type="number"
-          placeholder="0"
-          value={formData[trapsPerString] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={avgSoakTime}>{inputsMetadata.fields.trip[3].avgSoakTime.label[0].en}</Label>
-        <TextInput
-          id={avgSoakTime}
-          name={avgSoakTime}
-          type="number"
-          placeholder="0"
-          value={formData[avgSoakTime] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={avgSoakTime}>
-          {inputsMetadata.fields.trip[4].totNrBuoyLines.label[0].en}
-        </Label>
-        <TextInput
-          id={totNrBuoyLines}
-          name={totNrBuoyLines}
-          type="number"
-          placeholder="0"
-          value={formData[totNrBuoyLines] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={avgSoakTime}>Date Landed</Label>
-        <TextInput
-          id={date_land}
-          name={date_land}
-          type="text"
-          placeholder="1/1/2024"
-          value={formData[date_land] || ""}
-          onChange={handleChange}
-        />
-      </FormGroup>
-
-      <h3>Step 4: Effort Information</h3>
-      <FormGroup error={false}>
-        <Label htmlFor={numTrapsInWater}>
-          {inputsMetadata.fields.effort[0].numTrapsInWater.label[0].en}
-        </Label>
-        <TextInput
-          id={numTrapsInWater}
-          name={numTrapsInWater}
-          type="number"
-          placeholder="0"
-          value={formData[numTrapsInWater] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={numTrapsHauled}>
-          {inputsMetadata.fields.effort[1].numTrapsHauled.label[0].en}
-        </Label>
-        <TextInput
-          id={numTrapsHauled}
-          name={numTrapsHauled}
-          type="number"
-          placeholder="0"
-          value={formData[numTrapsHauled] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={numTrapsPerString}>
-          {inputsMetadata.fields.effort[2].numTrapsPerString.label[0].en}
-        </Label>
-        <TextInput
-          id={numTrapsPerString}
-          name={numTrapsPerString}
-          type="number"
-          placeholder="0"
-          value={formData[numTrapsPerString] || ""}
-          onChange={handleChange}
-        />
-        <Label htmlFor={numBuoyLines}>
-          {inputsMetadata.fields.effort[3].numBuoyLines.label[0].en}
-        </Label>
-        <TextInput
-          id={numBuoyLines}
-          name={numBuoyLines}
-          type="number"
-          placeholder="0"
-          value={formData[numBuoyLines] || ""}
-          onChange={handleChange}
-        />
-      </FormGroup>
-
-      <div className="grid-row flex-column">
-        <Button role="form-submit" type="submit">
-          {navigator.onLine ? "Online Submit" : "Offline Submit"}
+      {!formData?.currentStep && (
+        <Button type="button" onClick={initializeMultistepForm}>
+          Initialize Report Form
         </Button>
-      </div>
+      )}
+      {formData?.currentStep === 1 && <StepOne activityData={activityData} />}
+      {formData?.currentStep === 2 && <StepTwo speciesData={speciesData} />}
+      {formData?.currentStep === 3 && <StepThree />}
+      {formData?.currentStep === 4 && <StepFour />}
     </>
   );
 };

--- a/src/pages/ReportForm.jsx
+++ b/src/pages/ReportForm.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "../packages/react-components";
 import useOfflineStorage from "../hooks/useOfflineStorage.example";
 import { useParams } from "react-router-dom";
-import useMultiStepForm from "../hooks/useMultiStepForm";
+import useMultiStepForm, { TOTAL_STEPS } from "../hooks/useMultiStepForm";
 import { StepOne } from "../components/ReportForm/StepOne";
 import { StepTwo } from "../components/ReportForm/StepTwo";
 import { StepThree } from "../components/ReportForm/StepThree";
@@ -12,14 +12,31 @@ import { StepFour } from "../components/ReportForm/StepFour";
 
 const ReportForm = () => {
   const { findOfflineData } = useOfflineStorage();
-  const { tripReportId } = useParams();
+  const { tripReportId, formId } = useParams();
   const navigate = useNavigate();
-  const { init, formData } = useMultiStepForm(tripReportId);
+  const { init, formData, setFormData } = useMultiStepForm(formId);
 
   const [reportType, setReportType] = useState("");
   const [tripType, setTripType] = useState("");
   const [activityData, setActivityData] = useState([]);
   const [speciesData, setSpeciesData] = useState([]);
+
+  useEffect(() => {
+    const loadData = async () => {
+      if (formId) {
+        const found = await findOfflineData("formData", {
+          uuid: formId,
+        });
+        console.log(found[0]);
+        if (found) {
+          setFormData({ ...found[0], totalSteps: TOTAL_STEPS });
+        }
+      } else {
+        navigate(`/tripReport/${tripReportId}`);
+      }
+    };
+    loadData();
+  }, [formId]);
 
   useEffect(() => {
     const queryFormData = async () => {
@@ -45,20 +62,24 @@ const ReportForm = () => {
     navigate(`/tripReport/${tripReportId}/${uuid}`);
   };
 
+  if (!formData || !reportType || !tripType) {
+    return null;
+  }
+
   return (
     <>
       <h1>{reportType} Report Form</h1>
       <p>Trip Type: {tripType}</p>
 
-      {!formData?.currentStep && (
+      {!formData.currentStep && (
         <Button type="button" onClick={initializeMultistepForm}>
           Initialize Report Form
         </Button>
       )}
-      {formData?.currentStep === 1 && <StepOne activityData={activityData} />}
-      {formData?.currentStep === 2 && <StepTwo speciesData={speciesData} />}
-      {formData?.currentStep === 3 && <StepThree />}
-      {formData?.currentStep === 4 && <StepFour />}
+      {formData.currentStep === 1 && <StepOne activityData={activityData} />}
+      {formData.currentStep === 2 && <StepTwo speciesData={speciesData} />}
+      {formData.currentStep === 3 && <StepThree />}
+      {formData.currentStep === 4 && <StepFour />}
     </>
   );
 };

--- a/src/pages/TripReportTable.jsx
+++ b/src/pages/TripReportTable.jsx
@@ -4,7 +4,6 @@
  */
 
 import { useEffect, useState } from "react";
-import { flexRender } from "@tanstack/react-table";
 import { useTableState } from "../contexts/TableWrapper.example";
 import {
   Table,
@@ -39,7 +38,7 @@ const TripReportTable = () => {
 
   const handleRowClick = (row) => {
     const uuid = generateUUID();
-    navigate(`/tripReport/${row.original.KEY}/${uuid}`);
+    navigate(`/tripReport/${row.original.KEY}`);
   };
 
   if (!table) {

--- a/src/pages/TripReportTable.jsx
+++ b/src/pages/TripReportTable.jsx
@@ -39,7 +39,7 @@ const TripReportTable = () => {
 
   const handleRowClick = (row) => {
     const uuid = generateUUID();
-    navigate(`/tripReport/${row.id}/${uuid}`);
+    navigate(`/tripReport/${row.original.KEY}/${uuid}`);
   };
 
   if (!table) {


### PR DESCRIPTION
Extension of https://github.com/NMFS-RADFish/boilerplate/pull/72

Adds a `MultiStep` form to existing implementation. This form should cache data as user navigates through form. Current step of form should also be kept cached, to return to the last known step of each form (scoped by `formId`). All formData should be cached as user navigates to the form.

1. When a new form is created `{ isDraft: true }`
2. When form is submitted `{ isDraft: false }`
3. When a form is submitted offline `{ isDraft: false, offlineSubmit: true }`
4. When a form is submitted online: `{ isDraft: false, offlineSubmit: false }`

https://github.com/NMFS-RADFish/boilerplate/assets/35090461/91efa6bb-cf03-4b38-b9e9-eed3a7770163

A few things I ran into:

1. `asyncFormOptions` prop isn't really needed anymore, now that we cache things in offline storage
2. `flexRender` method isn't needed. We can just render `{ children }`, and leave it up to the developer to decide what to render. `cell.getValue()` is the easiest way to do this I think.
