### PR TITLE
Refactor toast implementation to be more extensible

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,19 +13,22 @@ import { SimpleTable } from "./pages/Table.example";
 import useOfflineStorage from "./hooks/useOfflineStorage.example";
 import { useOfflineStatus } from "./hooks/useOfflineStatus";
 import { ServerSync } from "./components/ServerSync";
-import { TOAST_CONFIG, useToast } from "./hooks/useToast";
+import { TOAST_CONFIG, TOAST_LIFESPAN, useToast } from "./hooks/useToast";
 
 const ApiService = new RadfishAPIService("");
 
 function App() {
   const [asyncFormOptions, setAsyncFormOptions] = useState({});
-  const { toast, showToast } = useToast();
+  const { toast, showToast, dismissToast } = useToast();
   const { isOffline } = useOfflineStatus();
   const { updateOfflineData, findOfflineData } = useOfflineStorage();
 
   useEffect(() => {
     if (isOffline) {
       showToast(TOAST_CONFIG.OFFLINE);
+      setTimeout(() => {
+        dismissToast();
+      }, TOAST_LIFESPAN);
     }
   }, [isOffline]);
 
@@ -70,6 +73,10 @@ function App() {
       showToast(TOAST_CONFIG.SUCCESS);
     } catch (err) {
       showToast(TOAST_CONFIG.ERROR);
+    } finally {
+      setTimeout(() => {
+        dismissToast();
+      }, TOAST_LIFESPAN);
     }
   };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import "./index.css";
 import React, { useState, useEffect } from "react";
 import { Routes, Route, BrowserRouter as Router } from "react-router-dom";
-import { Button, Toast } from "./packages/react-components";
+import { Toast } from "./packages/react-components";
 import { FormWrapper } from "./contexts/FormWrapper.example";
 import { TableWrapper } from "./contexts/TableWrapper.example";
 import Layout from "./components/Layout";
@@ -17,14 +17,17 @@ import { TOAST_CONFIG, useToast } from "./hooks/useToast";
 
 const ApiService = new RadfishAPIService("");
 
-// lifespan toast message should be visible in ms
-const TOAST_LIFESPAN = 2000;
-
 function App() {
   const [asyncFormOptions, setAsyncFormOptions] = useState({});
   const { toast, showToast } = useToast();
   const { isOffline } = useOfflineStatus();
   const { updateOfflineData, findOfflineData } = useOfflineStorage();
+
+  useEffect(() => {
+    if (isOffline) {
+      showToast(TOAST_CONFIG.OFFLINE);
+    }
+  }, [isOffline]);
 
   // when application mounts, fetch data from endpoint and set the payload to component state
   // this data is then passed into `DemoForm` component and used to prepopulate form fields (eg dropdown) with default options fetched from server

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import "./index.css";
 import React, { useState, useEffect } from "react";
 import { Routes, Route, BrowserRouter as Router } from "react-router-dom";
-import { Toast, ToastStatus } from "./packages/react-components";
+import { Button, Toast } from "./packages/react-components";
 import { FormWrapper } from "./contexts/FormWrapper.example";
 import { TableWrapper } from "./contexts/TableWrapper.example";
 import Layout from "./components/Layout";
@@ -13,6 +13,7 @@ import { SimpleTable } from "./pages/Table.example";
 import useOfflineStorage from "./hooks/useOfflineStorage.example";
 import { useOfflineStatus } from "./hooks/useOfflineStatus";
 import { ServerSync } from "./components/ServerSync";
+import { TOAST_CONFIG, useToast } from "./hooks/useToast";
 
 const ApiService = new RadfishAPIService("");
 
@@ -21,7 +22,7 @@ const TOAST_LIFESPAN = 2000;
 
 function App() {
   const [asyncFormOptions, setAsyncFormOptions] = useState({});
-  const [toast, setToast] = useState(null);
+  const { toast, showToast } = useToast();
   const { isOffline } = useOfflineStatus();
   const { updateOfflineData, findOfflineData } = useOfflineStorage();
 
@@ -63,15 +64,9 @@ function App() {
   const handleFormSubmit = async (submittedData) => {
     try {
       await ApiService.post(MSW_ENDPOINT.FORM, submittedData);
-      const { status, message } = ToastStatus.SUCCESS;
-      setToast({ status, message });
+      showToast(TOAST_CONFIG.SUCCESS);
     } catch (err) {
-      const { status, message } = ToastStatus.ERROR;
-      setToast({ status, message });
-    } finally {
-      setTimeout(() => {
-        setToast(null);
-      }, TOAST_LIFESPAN);
+      showToast(TOAST_CONFIG.ERROR);
     }
   };
 

--- a/src/__tests__/components/Toast.test.jsx
+++ b/src/__tests__/components/Toast.test.jsx
@@ -10,7 +10,7 @@ describe("Toast Component", () => {
   });
 
   test("renders Success Alert when toast status is 'success'", () => {
-    const toast = { status: "offline", message: "Application currently offline" };
+    const toast = { status: "success", message: "Application currently offline" };
     render(<Toast toast={toast} />);
     const offlineAlert = screen.getByRole("toast-notification");
     expect(offlineAlert).toBeInTheDocument();

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+// lifespan toast message should be visible in ms
+const TOAST_LIFESPAN = 2000;
+/**
+ * Toast configuration constants.
+ * @constant {Object}
+ */
+export const TOAST_CONFIG = {
+  OFFLINE: {
+    status: "error",
+    message: "Application currently offline",
+  },
+  SUCCESS: {
+    status: "success",
+    message: "Successful form submission",
+  },
+  ERROR: {
+    status: "error",
+    message: "Error submitting form",
+  },
+};
+
+export const useToast = () => {
+  const [toast, setToast] = useState(null);
+
+  const showToast = (toast) => {
+    setToast({ status: toast.status, message: toast.message });
+    setTimeout(() => {
+      setToast(null);
+    }, TOAST_LIFESPAN);
+  };
+
+  return { toast, showToast };
+};

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 // lifespan toast message should be visible in ms
-const TOAST_LIFESPAN = 2000;
+export const TOAST_LIFESPAN = 2000;
 /**
  * Toast configuration constants.
  * @constant {Object}
@@ -26,10 +26,11 @@ export const useToast = () => {
 
   const showToast = (toastObj) => {
     setToast({ status: toastObj.status, message: toastObj.message });
-    setTimeout(() => {
-      setToast(null);
-    }, TOAST_LIFESPAN);
   };
 
-  return { toast, showToast };
+  const dismissToast = () => {
+    setToast(null);
+  };
+
+  return { toast, showToast, dismissToast };
 };

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -24,8 +24,8 @@ export const TOAST_CONFIG = {
 export const useToast = () => {
   const [toast, setToast] = useState(null);
 
-  const showToast = (toast) => {
-    setToast({ status: toast.status, message: toast.message });
+  const showToast = (toastObj) => {
+    setToast({ status: toastObj.status, message: toastObj.message });
     setTimeout(() => {
       setToast(null);
     }, TOAST_LIFESPAN);

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -8,7 +8,7 @@ export const TOAST_LIFESPAN = 2000;
  */
 export const TOAST_CONFIG = {
   OFFLINE: {
-    status: "error",
+    status: "warning",
     message: "Application currently offline",
   },
   SUCCESS: {

--- a/src/packages/react-components/alerts/index.jsx
+++ b/src/packages/react-components/alerts/index.jsx
@@ -11,11 +11,7 @@ import { Alert } from "@trussworks/react-uswds";
  * @returns {JSX.Element | undefined} The JSX element representing the toast notification.
  */
 const RadfishToast = ({ toast }) => {
-  if (!toast) {
-    return;
-  }
-
-  switch (toast.status) {
+  switch (toast?.status) {
     case "success":
       return (
         <Alert role="toast-notification" type={"success"} headingLevel={"h1"}>

--- a/src/packages/react-components/alerts/index.jsx
+++ b/src/packages/react-components/alerts/index.jsx
@@ -3,25 +3,6 @@ import React from "react";
 import { Alert } from "@trussworks/react-uswds";
 
 /**
- * Toast configuration constants.
- * @constant {Object}
- */
-const ToastStatus = {
-  OFFLINE: {
-    status: "offline",
-    message: "Application currently offline",
-  },
-  SUCCESS: {
-    status: "success",
-    message: "Successful form submission",
-  },
-  ERROR: {
-    status: "error",
-    message: "Error submitting form",
-  },
-};
-
-/**
  * Functional component for rendering a toast notification based on the provided toast object.
  *
  * @component
@@ -35,42 +16,21 @@ const RadfishToast = ({ toast }) => {
   }
 
   switch (toast.status) {
-    case ToastStatus.OFFLINE.status:
+    case "success":
       return (
-        <Alert
-          role="toast-notification"
-          type={"error"}
-          headingLevel={"h1"}
-          hidden={toast.status !== ToastStatus.OFFLINE.status}
-        >
+        <Alert role="toast-notification" type={"success"} headingLevel={"h1"}>
           {toast.message}
         </Alert>
       );
-    case ToastStatus.SUCCESS.status:
+    case "error":
       return (
-        <Alert
-          role="toast-notification"
-          type={"success"}
-          headingLevel={"h1"}
-          hidden={toast.status !== ToastStatus.SUCCESS.status}
-        >
-          {toast.message}
-        </Alert>
-      );
-    case ToastStatus.ERROR.status:
-      return (
-        <Alert
-          role="toast-notification"
-          type={"error"}
-          headingLevel={"h1"}
-          hidden={toast.status !== ToastStatus.ERROR.status}
-        >
+        <Alert role="toast-notification" type={"error"} headingLevel={"h1"}>
           {toast.message}
         </Alert>
       );
     default:
-      return;
+      return null;
   }
 };
 
-export { RadfishToast as Toast, ToastStatus };
+export { RadfishToast as Toast };

--- a/src/packages/react-components/alerts/index.jsx
+++ b/src/packages/react-components/alerts/index.jsx
@@ -24,6 +24,18 @@ const RadfishToast = ({ toast }) => {
           {toast.message}
         </Alert>
       );
+    case "info":
+      return (
+        <Alert role="toast-notification" type={"info"} headingLevel={"h1"}>
+          {toast.message}
+        </Alert>
+      );
+    case "warning":
+      return (
+        <Alert role="toast-notification" type={"warning"} headingLevel={"h1"}>
+          {toast.message}
+        </Alert>
+      );
     default:
       return null;
   }

--- a/src/pages/ComplexForm.example.jsx
+++ b/src/pages/ComplexForm.example.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Alert, Checkbox, FormGroup } from "@trussworks/react-uswds";
 import {
   TextInput,
@@ -7,8 +7,6 @@ import {
   Button,
   Label,
   ErrorMessage,
-  // Toast,
-  // ToastStatus,
 } from "../packages/react-components";
 import { useFormState } from "../contexts/FormWrapper.example";
 import { fullNameValidators } from "../utilities";

--- a/src/pages/ComplexForm.example.jsx
+++ b/src/pages/ComplexForm.example.jsx
@@ -15,7 +15,7 @@ import { fullNameValidators } from "../utilities";
 import useOfflineStorage from "../hooks/useOfflineStorage.example";
 import { CONSTANTS } from "../config/form";
 import "../styles/theme.css";
-import { TOAST_CONFIG, useToast } from "../hooks/useToast";
+import { TOAST_CONFIG, TOAST_LIFESPAN, useToast } from "../hooks/useToast";
 
 const { fullName, numberOfFish, radioOption, species, subSpecies, computedPrice } = CONSTANTS;
 
@@ -36,7 +36,7 @@ const ComplexForm = ({ asyncFormOptions }) => {
     validationErrors,
     handleMultiEntrySubmit,
   } = useFormState();
-  const { toast, showToast } = useToast();
+  const { showToast, dismissToast } = useToast();
 
   const { createOfflineData } = useOfflineStorage();
 
@@ -47,6 +47,10 @@ const ComplexForm = ({ asyncFormOptions }) => {
       showToast(TOAST_CONFIG.SUCCESS);
     } catch (err) {
       showToast(TOAST_CONFIG.ERROR);
+    } finally {
+      setTimeout(() => {
+        dismissToast();
+      }, TOAST_LIFESPAN);
     }
   };
 

--- a/src/pages/ComplexForm.example.jsx
+++ b/src/pages/ComplexForm.example.jsx
@@ -7,14 +7,15 @@ import {
   Button,
   Label,
   ErrorMessage,
-  Toast,
-  ToastStatus,
+  // Toast,
+  // ToastStatus,
 } from "../packages/react-components";
 import { useFormState } from "../contexts/FormWrapper.example";
 import { fullNameValidators } from "../utilities";
 import useOfflineStorage from "../hooks/useOfflineStorage.example";
 import { CONSTANTS } from "../config/form";
 import "../styles/theme.css";
+import { TOAST_CONFIG, useToast } from "../hooks/useToast";
 
 const { fullName, numberOfFish, radioOption, species, subSpecies, computedPrice } = CONSTANTS;
 
@@ -35,8 +36,7 @@ const ComplexForm = ({ asyncFormOptions }) => {
     validationErrors,
     handleMultiEntrySubmit,
   } = useFormState();
-  const [toast, setToast] = useState(null);
-  const TOAST_LIFESPAN = 2000;
+  const { toast, showToast } = useToast();
 
   const { createOfflineData } = useOfflineStorage();
 
@@ -44,23 +44,14 @@ const ComplexForm = ({ asyncFormOptions }) => {
     e.preventDefault();
     try {
       await createOfflineData("formData", formData);
-      const { status, message } = ToastStatus.SUCCESS;
-      setToast({ status, message });
+      showToast(TOAST_CONFIG.SUCCESS);
     } catch (err) {
-      const { status, message } = ToastStatus.ERROR;
-      setToast({ status, message });
-    } finally {
-      setTimeout(() => {
-        setToast(null);
-      }, TOAST_LIFESPAN);
+      showToast(TOAST_CONFIG.ERROR);
     }
   };
 
   return (
     <>
-      <div className="toast-container">
-        <Toast toast={toast} />
-      </div>
       <FormGroup error={validationErrors[fullName]}>
         <Label htmlFor={fullName}>Full Name</Label>
         {validationErrors[fullName] && <ErrorMessage>{validationErrors[fullName]}</ErrorMessage>}

--- a/src/pages/Table.example.jsx
+++ b/src/pages/Table.example.jsx
@@ -3,7 +3,7 @@
  * @returns {React.ReactNode} - The demo table component.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useTableState } from "../contexts/TableWrapper.example";
 import { MSW_ENDPOINT } from "../mocks/handlers";
 import RadfishAPIService from "../packages/services/APIService";
@@ -20,15 +20,12 @@ import {
   TablePaginationPageCount,
   TablePaginationGoToPage,
   TablePaginationSelectRowCount,
-  Toast,
-  ToastStatus,
 } from "../packages/react-components";
 import { useNavigate } from "react-router-dom";
-const TOAST_LIFESPAN = 3000;
 import useOfflineStorage from "../hooks/useOfflineStorage.example";
-import { Alert, Grid } from "@trussworks/react-uswds";
+import { Alert } from "@trussworks/react-uswds";
 import { COMMON_CONFIG } from "../config/common";
-import { GridContainer } from "@trussworks/react-uswds";
+import { TOAST_CONFIG, useToast } from "../hooks/useToast";
 
 const ApiService = new RadfishAPIService("");
 
@@ -50,7 +47,7 @@ const SimpleTable = () => {
     setShowOfflineSubmit,
   } = useTableState();
   const navigate = useNavigate();
-  const [toast, setToast] = useState(null);
+  const { toast, showToast } = useToast();
   const { findOfflineData, deleteOfflineData } = useOfflineStorage();
   // Check if the app is offline
   // const isOffline = !navigator.onLine;
@@ -124,21 +121,14 @@ const SimpleTable = () => {
       //delete submitted drafts from local storage
       const idsFromApiResponse = data.map((item) => item.id);
       deleteOfflineData("formData", idsFromApiResponse);
-      const { status, message } = ToastStatus.SUCCESS;
-      setToast({ status, message });
+      showToast(TOAST_CONFIG.SUCCESS);
     } catch (error) {
-      const { status, message } = ToastStatus.ERROR;
-      setToast({ status, message });
-    } finally {
-      setTimeout(() => {
-        setToast(null);
-      }, TOAST_LIFESPAN);
+      showToast(TOAST_CONFIG.ERROR);
     }
   };
 
   return (
     <>
-      <Toast toast={toast} />
       <TableInfoAnnotation />
       <br />
       <div className="margin-left-auto display-flex flex-column flex-align-end width-auto">

--- a/src/pages/Table.example.jsx
+++ b/src/pages/Table.example.jsx
@@ -47,7 +47,7 @@ const SimpleTable = () => {
     setShowOfflineSubmit,
   } = useTableState();
   const navigate = useNavigate();
-  const { toast, showToast } = useToast();
+  const { showToast, dismissToast } = useToast();
   const { findOfflineData, deleteOfflineData } = useOfflineStorage();
   // Check if the app is offline
   // const isOffline = !navigator.onLine;
@@ -124,6 +124,10 @@ const SimpleTable = () => {
       showToast(TOAST_CONFIG.SUCCESS);
     } catch (error) {
       showToast(TOAST_CONFIG.ERROR);
+    } finally {
+      setTimeout(() => {
+        dismissToast();
+      }, TOAST_LIFESPAN);
     }
   };
 


### PR DESCRIPTION
Refactors the Toast implementation for the following reasons:

1. Lift out configuration from `react-radfish` package into application code (developer will need to change this)
2. Add additional `Alert` types
3. Create reusable hooks for `useOfflineStatus` and `useToast` to make the code a bit cleaner and DRY.