### PR TITLE
Update version number across examples

### DIFF
--- a/examples/computed-fields/package.json
+++ b/examples/computed-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/dynamic-form/package.json
+++ b/examples/dynamic-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/field-validators/package.json
+++ b/examples/field-validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/multistep-form/package.json
+++ b/examples/multistep-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/network-status/package.json
+++ b/examples/network-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/on-device-storage/package.json
+++ b/examples/on-device-storage/package.json
@@ -1,86 +1,86 @@
 {
-	"name": "main-example",
-	"version": "0.8.0",
-	"private": true,
-	"dependencies": {
-		"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-		"@tanstack/react-table": "^8.11.7",
-		"@testing-library/user-event": "^13.5.0",
-		"@trussworks/react-uswds": "^6.1.0",
-		"dexie": "^3.2.5",
-		"dexie-react-hooks": "^1.1.7",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
-		"react-router-dom": "^6.21.2",
-		"web-vitals": "^2.1.4",
-		"workbox-background-sync": "^7.0.0",
-		"workbox-broadcast-update": "^7.0.0",
-		"workbox-cacheable-response": "^7.0.0",
-		"workbox-core": "^7.0.0",
-		"workbox-expiration": "^7.0.0",
-		"workbox-google-analytics": "^7.0.0",
-		"workbox-navigation-preload": "^7.0.0",
-		"workbox-precaching": "^7.0.0",
-		"workbox-range-requests": "^7.0.0",
-		"workbox-routing": "^7.0.0",
-		"workbox-strategies": "^7.0.0",
-		"workbox-streams": "^7.0.0"
-	},
-	"scripts": {
-		"start": "vite",
-		"build": "vite build",
-		"prebuild": "rm -rf dist",
-		"test": "vitest --exclude './src/__tests__/e2e/**'",
-		"test:e2e": "concurrently --kill-others --success first \"npm start\" \"vitest './src/__tests__/e2e/integration.e2e.test.jsx'\"",
-		"lint": "eslint src",
-		"lint:fix": "eslint --fix src",
-		"format": "prettier --write src --config ./.prettierrc",
-		"serve": "vite preview",
-		"lhci:mobile": "lhci autorun",
-		"lhci:desktop": "lhci autorun --collect.settings.preset=desktop"
-	},
-	"eslintConfig": {
-		"extends": [
-			"react-app",
-			"react-app/jest"
-		]
-	},
-	"browserslist": {
-		"production": [
-			">0.2%",
-			"not dead",
-			"not op_mini all"
-		],
-		"development": [
-			"last 1 chrome version",
-			"last 1 firefox version",
-			"last 1 safari version"
-		]
-	},
-	"devDependencies": {
-		"@babel/preset-env": "^7.24.0",
-		"@babel/preset-react": "^7.23.3",
-		"@lhci/cli": "^0.13.0",
-		"@testing-library/jest-dom": "6.4.2",
-		"@testing-library/react": "^14.2.2",
-		"@vitejs/plugin-react": "^4.2.1",
-		"babel-jest": "^29.7.0",
-		"concurrently": "^8.2.2",
-		"eslint": "^8.55.0",
-		"eslint-plugin-prettier": "^5.0.1",
-		"eslint-plugin-react": "^7.33.2",
-		"eslint-plugin-react-hooks": "^4.6.0",
-		"jsdom": "24.0.0",
-		"msw": "^2.0.12",
-		"pptr-testing-library": "^0.8.0",
-		"prettier": "^3.1.0",
-		"puppeteer": "^22.6.5",
-		"react-test-renderer": "^18.2.0",
-		"vite": "^5.1.5",
-		"vite-plugin-pwa": "0.19.2",
-		"vitest": "1.4.0"
-	},
-	"msw": {
-		"workerDirectory": "public"
-	}
+  "name": "main-example",
+  "version": "0.9.0",
+  "private": true,
+  "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@tanstack/react-table": "^8.11.7",
+    "@testing-library/user-event": "^13.5.0",
+    "@trussworks/react-uswds": "^6.1.0",
+    "dexie": "^3.2.5",
+    "dexie-react-hooks": "^1.1.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2",
+    "web-vitals": "^2.1.4",
+    "workbox-background-sync": "^7.0.0",
+    "workbox-broadcast-update": "^7.0.0",
+    "workbox-cacheable-response": "^7.0.0",
+    "workbox-core": "^7.0.0",
+    "workbox-expiration": "^7.0.0",
+    "workbox-google-analytics": "^7.0.0",
+    "workbox-navigation-preload": "^7.0.0",
+    "workbox-precaching": "^7.0.0",
+    "workbox-range-requests": "^7.0.0",
+    "workbox-routing": "^7.0.0",
+    "workbox-strategies": "^7.0.0",
+    "workbox-streams": "^7.0.0"
+  },
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "prebuild": "rm -rf dist",
+    "test": "vitest --exclude './src/__tests__/e2e/**'",
+    "test:e2e": "concurrently --kill-others --success first \"npm start\" \"vitest './src/__tests__/e2e/integration.e2e.test.jsx'\"",
+    "lint": "eslint src",
+    "lint:fix": "eslint --fix src",
+    "format": "prettier --write src --config ./.prettierrc",
+    "serve": "vite preview",
+    "lhci:mobile": "lhci autorun",
+    "lhci:desktop": "lhci autorun --collect.settings.preset=desktop"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.23.3",
+    "@lhci/cli": "^0.13.0",
+    "@testing-library/jest-dom": "6.4.2",
+    "@testing-library/react": "^14.2.2",
+    "@vitejs/plugin-react": "^4.2.1",
+    "babel-jest": "^29.7.0",
+    "concurrently": "^8.2.2",
+    "eslint": "^8.55.0",
+    "eslint-plugin-prettier": "^5.0.1",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "jsdom": "24.0.0",
+    "msw": "^2.0.12",
+    "pptr-testing-library": "^0.8.0",
+    "prettier": "^3.1.0",
+    "puppeteer": "^22.6.5",
+    "react-test-renderer": "^18.2.0",
+    "vite": "^5.1.5",
+    "vite-plugin-pwa": "0.19.2",
+    "vitest": "1.4.0"
+  },
+  "msw": {
+    "workerDirectory": "public"
+  }
 }

--- a/examples/on-device-storage/package.json
+++ b/examples/on-device-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.9.0",
+  "version": "0.8.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/server-sync/package.json
+++ b/examples/server-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/simple-form/package.json
+++ b/examples/simple-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/examples/simple-table/package.json
+++ b/examples/simple-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-example",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
This is needed in order for the latest version `0.9.0` to be shown across all example UIs.