### PR TITLE
Add default sort icon for clarity of sortability

### DIFF
--- a/examples/simple-table/src/App.jsx
+++ b/examples/simple-table/src/App.jsx
@@ -1,6 +1,6 @@
 import "./index.css";
 import React, { useEffect } from "react";
-import { Alert } from "@trussworks/react-uswds";
+import { Alert, Button } from "@trussworks/react-uswds";
 import {
   TableBody,
   TableBodyRow,
@@ -8,7 +8,6 @@ import {
   TableHeader,
   TableHeaderRow,
   TableBodyCell,
-  Button,
   TablePaginationNav,
   TablePaginationPageCount,
   TablePaginationGoToPage,

--- a/packages/react-radfish/table/index.jsx
+++ b/packages/react-radfish/table/index.jsx
@@ -1,9 +1,12 @@
 import "./style.css";
 import { flexRender } from "@tanstack/react-table";
-import { Table as TwTable } from "@trussworks/react-uswds";
-import { Icon } from "@trussworks/react-uswds";
-import { TextInput, Select } from "../inputs";
-import { Button } from "../buttons";
+import {
+  Table as TwTable,
+  TextInput,
+  Select,
+  Button,
+  Icon,
+} from "@trussworks/react-uswds";
 
 const RADFishTable = (props) => {
   return <TwTable {...props}>{props.children}</TwTable>;
@@ -77,7 +80,7 @@ const RADFishSortDirectionIcon = ({ header }) => {
     case "desc":
       return <Icon.ArrowDownward />;
     default:
-      return null;
+      return <Icon.UnfoldMore />;
   }
 };
 


### PR DESCRIPTION
Adds a default sort icon to make it more clear that these columns are sortable by click. Also makes some corrections to components that no longer exist in `react-radfish` to come from `trussworks`

Note that this will require a patched release of the component library to be published.

https://github.com/NMFS-RADFish/boilerplate/assets/35090461/fb6c95b1-1edb-46b5-8436-697f05e276e7

