### PR TITLE
Move dispatch toast method outside of react hook

### DIFF
--- a/packages/react-radfish/hooks/useToast/useToast.js
+++ b/packages/react-radfish/hooks/useToast/useToast.js
@@ -7,6 +7,13 @@ export const TOAST_STATUS = {
   INFO: "info",
 };
 
+export const dispatchToast = ({ message, status, duration = 2000 }) => {
+  const toast = new CustomEvent("@nmfs-radfish/react-radfish:dispatchToast", {
+    detail: { message, status, duration, expires_at: Date.now() + duration },
+  });
+  document.dispatchEvent(toast);
+};
+
 export const useToast = () => {
   const [toasts, setToasts] = useState([]);
 
@@ -40,11 +47,5 @@ export const useToast = () => {
   return {
     toasts,
     setToasts,
-    dispatchToast: ({ message, status, duration = 2000 }) => {
-      const toast = new CustomEvent("@nmfs-radfish/react-radfish:dispatchToast", {
-        detail: { message, status, duration, expires_at: Date.now() + duration },
-      });
-      document.dispatchEvent(toast);
-    },
   };
 };

--- a/packages/react-radfish/hooks/useToast/useToast.spec.js
+++ b/packages/react-radfish/hooks/useToast/useToast.spec.js
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { useToast } from "./useToast";
+import { useToast, dispatchToast } from "./useToast";
 
 describe("useToast", () => {
   it("should dispatch a toast event", () => {
@@ -7,7 +7,7 @@ describe("useToast", () => {
 
     const {
       result: {
-        current: { toasts, dispatchToast },
+        current: { toasts },
       },
     } = renderHook(() => useToast());
 


### PR DESCRIPTION
The `dispatchToast` should be exported directly from the package instead of from the hook. There was a previous intermediary implementation that relied on the dispatcher needing access to the react state, but that isn't the case anymore.