### PR TITLE
Fix dispatchToast reference in Application component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2968,7 +2968,7 @@
     },
     "packages/react-radfish": {
       "name": "@nmfs-radfish/react-radfish",
-      "version": "0.4.0",
+      "version": "0.4.9",
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-table": "^8.16.0",

--- a/packages/react-radfish/Application/index.jsx
+++ b/packages/react-radfish/Application/index.jsx
@@ -1,16 +1,16 @@
 import { Toast } from "../alerts";
-import { createContext, useState, useEffect, useContext } from "react";
-import { useOfflineStatus, useToast } from "../hooks";
+import { createContext, useEffect, useContext } from "react";
+import { useOfflineStatus, useToasts, dispatchToast } from "../hooks";
 
 const ApplicationContext = createContext();
 
 function ApplicationComponent(props) {
-  const { toasts, setToasts, dispatchToast } = useToast();
+  const { toasts } = useToasts();
   const { isOffline } = useOfflineStatus();
 
   useEffect(() => {
     if (!isOffline) {
-      dispatchToast({ message: "Application is online", status: "info", duration: 2000 });
+      dispatchToast({ message: "Application is online", status: "info", duration: 3000 });
     }
   }, [isOffline]);
 

--- a/packages/react-radfish/hooks/useToast/useToast.js
+++ b/packages/react-radfish/hooks/useToast/useToast.js
@@ -14,7 +14,7 @@ export const dispatchToast = ({ message, status, duration = 2000 }) => {
   document.dispatchEvent(toast);
 };
 
-export const useToast = () => {
+export const useToasts = () => {
   const [toasts, setToasts] = useState([]);
 
   useEffect(() => {

--- a/packages/react-radfish/hooks/useToast/useToast.spec.js
+++ b/packages/react-radfish/hooks/useToast/useToast.spec.js
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { useToast, dispatchToast } from "./useToast";
+import { useToasts, dispatchToast } from "./useToast";
 
 describe("useToast", () => {
   it("should dispatch a toast event", () => {
@@ -9,7 +9,7 @@ describe("useToast", () => {
       result: {
         current: { toasts },
       },
-    } = renderHook(() => useToast());
+    } = renderHook(() => useToasts());
 
     dispatchToast({ message: "Hello", status: "ok" });
 

--- a/packages/react-radfish/package.json
+++ b/packages/react-radfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nmfs-radfish/react-radfish",
-  "version": "0.4.0",
+  "version": "0.4.9",
   "type": "module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The `useToasts` hook doesn't export dispatchToast method anymore, and the import should be coming from the hooks module.