### PR TITLE
85 docs   fix syntax error in on device storage readmemd

### DIFF
--- a/examples/on-device-storage/README.md
+++ b/examples/on-device-storage/README.md
@@ -62,7 +62,7 @@ The `useOfflineStorage` hook returns an object with the following methods:
 - `findOfflineData(tableName, criteria)` — Finds data in the storage based on the given criteria, returns all data if not criteria parameter is passed.
 
   - `tableName`: Name of the IndexedDB name
-  - `criteria`: The criteria object to use for finding data, eg {uuid: 123}.
+  - `criteria`: The criteria object to use for finding data, eg `{uuid: 123}`.
   - Returns a promise that resolves to an array of tuples:
     `[ [ uuid, { key: value } ], [ uuid2, { key: value } ] ]`
 

--- a/examples/server-sync/README.md
+++ b/examples/server-sync/README.md
@@ -29,6 +29,7 @@ Learn more about RADFish examples at the official [documentation](https://nmfs-r
    ```
 
 2. Import the component and required hooks in your project:
+
    ```javascript
    import { ServerSync } from "./components/ServerSync";
    ```
@@ -46,9 +47,9 @@ function App() {
     </div>
   );
 }
-```
 
 export default App;
+```
 
 ## Adding Network Requests and Updating Offline Storage
 


### PR DESCRIPTION
Fixed syntax of code snippets to prevent them from breaking `docusaurus-plugin-remote-content` when processing `README.md` files.