### PR TITLE
RADFish - GH Template: Create templates for Bug, Feature and PR (#191)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: "Bug Report 🐛"
 description: "Report a bug to help RADFish improve."
-title: "RADFish Boilerplate - Bug: [YOUR BUG TITLE HERE]"
+title: "RADFish Boilerplate - Bug: [Enter a title]"
 labels: ['bug']
 body:
   - type: textarea
@@ -62,13 +62,13 @@ body:
       description: "Provide any other relevant context or information about the issue."
     validations:
       required: false
-  # - type: checkboxes
-  #   id: confirmation
-  #   attributes:
-  #     label: "Code of Conduct Agreement"
-  #     description: "Please confirm the following:"
-  #     options:
-  #       - label: "I agree to follow this project's [Code of Conduct](https://example.com/code-of-conduct)."
-  #         required: true
-  #       - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
-  #         required: true
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: "Code of Conduct Agreement"
+      description: "Please confirm the following:"
+      options:
+        - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
+          required: true
+        # - label: "I agree to follow this project's [Code of Conduct](https://example.com/code-of-conduct)."
+        #   required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: "Bug Report 🐛"
+description: "Report a bug to help RADFish improve."
+title: "RADFish Boilerplate - Bug: [YOUR BUG TITLE HERE]"
+labels: ['bug']
+body:
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: "Bug Description"
+      description: "Provide a clear and detailed description of the bug you're experiencing. Include whether it affects major or minor functionality and if there's a workaround."
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: "Steps to Reproduce"
+      description: "List the steps that lead to the bug."
+      placeholder: |
+        1. Navigate to '...'
+        2. Perform '....'
+        3. Scroll to '....'
+        4. See the issue...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "Expected Outcome"
+      description: "Describe what you expected to happen."
+    validations:
+      required: true
+  - type: textarea
+    id: related-code
+    attributes:
+      label: "Relevant Code"
+      description: "Include any code snippets or links to the relevant code that may help resolve the bug (if available)."
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: "Screenshots"
+      description: "Attach screenshots to illustrate the issue, if applicable."
+    validations:
+      required: false
+  - type: textarea
+    id: system-info
+    attributes:
+      label: "System Information"
+      description: "Provide details about your system, including the version of the software, operating system, and browser."
+      placeholder: |
+        - Version:
+        - Device:
+        - Operating System:
+        - Browser and version:
+    validations:
+      required: false
+  - type: textarea
+    id: additional-details
+    attributes:
+      label: "Additional Information"
+      description: "Provide any other relevant context or information about the issue."
+    validations:
+      required: false
+  # - type: checkboxes
+  #   id: confirmation
+  #   attributes:
+  #     label: "Code of Conduct Agreement"
+  #     description: "Please confirm the following:"
+  #     options:
+  #       - label: "I agree to follow this project's [Code of Conduct](https://example.com/code-of-conduct)."
+  #         required: true
+  #       - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
+  #         required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     id: issue-description
     attributes:
       label: "Bug Description"
-      description: "Provide a clear and detailed description of the bug you're experiencing. Include whether it affects major or minor functionality and if there's a workaround."
+      description: "A clear and concise description of what the bug is."
     validations:
       required: true
   - type: textarea
@@ -25,17 +25,10 @@ body:
   - type: textarea
     id: expected-behavior
     attributes:
-      label: "Expected Outcome"
-      description: "Describe what you expected to happen."
+      label: "Expected Behavior"
+      description: "What did you expect to happen?"
     validations:
       required: true
-  - type: textarea
-    id: related-code
-    attributes:
-      label: "Relevant Code"
-      description: "Include any code snippets or links to the relevant code that may help resolve the bug (if available)."
-    validations:
-      required: false
   - type: textarea
     id: screenshots
     attributes:
@@ -62,13 +55,13 @@ body:
       description: "Provide any other relevant context or information about the issue."
     validations:
       required: false
-  - type: checkboxes
-    id: confirmation
-    attributes:
-      label: "Code of Conduct Agreement"
-      description: "Please confirm the following:"
-      options:
-        - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
-          required: true
+  # - type: checkboxes
+  #   id: confirmation
+  #   attributes:
+  #     label: "Code of Conduct Agreement"
+  #     description: "Please confirm the following:"
+  #     options:
+  #       - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
+  #         required: true
         # - label: "I agree to follow this project's [Code of Conduct](https://example.com/code-of-conduct)."
         #   required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,46 +6,39 @@ body:
   - type: textarea
     id: summary
     attributes:
-      label: "Feature Summary"
-      description: "Provide a brief overview of the feature you're suggesting."
+      label: "Feature Description"
+      description: "A clear and concise description of the feature you are requesting."
     validations:
       required: true
   - type: textarea
     id: problem-statement
     attributes:
-      label: "What problem does this feature solve?"
-      description: "Explain the problem you're facing that this feature will address."
+      label: "Why is this feature important?"
+      description: "Explain why this feature would improve the project or solve a specific problem."
     validations:
       required: true
   - type: textarea
     id: proposed-solution
     attributes:
-      label: "Proposed Solution"
-      description: "Describe the feature or change you'd like to see."
+      label: "How should this feature work?"
+      description: "Describe how you imagine the feature working or how it could be implemented."
     validations:
       required: true
-  - type: textarea
-    id: alternative-solutions
-    attributes:
-      label: "Considered Alternatives"
-      description: "Mention any alternative solutions or features you've thought about."
-    validations:
-      required: false
   - type: textarea
     id: extra-context
     attributes:
       label: "Additional Context"
-      description: "Add any extra context or information related to the feature request."
+      description: "Add any other context, screenshots, or references to help explain your request."
     validations:
       required: false
-  - type: checkboxes
-    id: agreement
-    attributes:
-      label: "Code of Conduct Confirmation"
-      description: "Please confirm the following:"
-      options:
-        - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
-          required: true
+  # - type: checkboxes
+  #   id: agreement
+  #   attributes:
+  #     label: "Code of Conduct Confirmation"
+  #     description: "Please confirm the following:"
+  #     options:
+  #       - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
+  #         required: true
         # - label: "I agree to follow this project's [Code of Conduct](https://example.com/code-of-conduct)."
         #   required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: "Feature Request ✨"
+description: "Suggest a new feature or improvement for this project."
+title: "Feature Request: [Enter a title]"
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Feature Summary"
+      description: "Provide a brief overview of the feature you're suggesting."
+    validations:
+      required: true
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: "What problem does this feature solve?"
+      description: "Explain the problem you're facing that this feature will address."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: "Proposed Solution"
+      description: "Describe the feature or change you'd like to see."
+    validations:
+      required: true
+  - type: textarea
+    id: alternative-solutions
+    attributes:
+      label: "Considered Alternatives"
+      description: "Mention any alternative solutions or features you've thought about."
+    validations:
+      required: false
+  - type: textarea
+    id: extra-context
+    attributes:
+      label: "Additional Context"
+      description: "Add any extra context or information related to the feature request."
+    validations:
+      required: false
+  - type: checkboxes
+    id: agreement
+    attributes:
+      label: "Code of Conduct Confirmation"
+      description: "Please confirm the following:"
+      options:
+        - label: "I have searched for duplicate issues in the [issue tracker](https://github.com/NMFS-RADFish/boilerplate/issues)."
+          required: true
+        # - label: "I agree to follow this project's [Code of Conduct](https://example.com/code-of-conduct)."
+        #   required: true
+

--- a/.github/ISSUE_TEMPLATE/pull_request_templated.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_templated.md
@@ -10,8 +10,8 @@ To ensure a smooth review and merge process, please consider the following:
 
 - Feel free to remove any sections of this template that aren’t relevant to your PR (including this welcome message!).
 
-- You can learn more about contributing by reading our
-  [official contribute doc](https://nmfs-radfish.github.io/radfish/about/contribute).
+- You can learn more about making a pull request by reading our
+  [official documentation](https://nmfs-radfish.github.io/radfish/about/contribute#6-how-to-make-a-pull-request).
   If you have any questions, don’t hesitate to get in touch.
 
 -->

--- a/.github/ISSUE_TEMPLATE/pull_request_templated.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_templated.md
@@ -18,8 +18,8 @@ To ensure a smooth review and merge process, please consider the following:
 
 <!---
 Step 1: Please use the following format for your PR title:
-RADFish - [Component]: [Short description of what this PR fixes or adds]
-Example: "RADFish - Form: Improve validation for email input"
+RADFish - [Component]: [Brief description of the change] (#IssueNumber)
+Example: "RADFish - Button: Increase font size for accessibility (#321)"
  -->
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/pull_request_templated.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_templated.md
@@ -1,0 +1,51 @@
+<!---
+Hello and thank you for contributing to RADFish!
+
+Your help is essential to the success of the project, and we truly appreciate your time and effort. 
+To ensure a smooth review and merge process, please consider the following:
+
+- This pull request (PR) template is here to help speed things along.
+  Every PR is reviewed by the RADFish Core team before it’s merged into the codebase.
+  Providing clear and thorough explanations of both the problem and your solution will make the review process quicker and more efficient.
+
+- Feel free to remove any sections of this template that aren’t relevant to your PR (including this welcome message!).
+
+- You can learn more about contributing by reading our
+  [official contribute doc](https://nmfs-radfish.github.io/radfish/about/contribute).
+  If you have any questions, don’t hesitate to get in touch.
+
+-->
+
+<!---
+Step 1: Please use the following format for your PR title:
+RADFish - [Component]: [Short description of what this PR fixes or adds]
+Example: "RADFish - Form: Improve validation for email input"
+ -->
+
+## Description
+
+<!-- Please include a summary of the changes and the related issue(s). Explain why this change is necessary and what problem it solves. -->
+
+<!-- Fixes # (issue number) Example: Fixes #123 -->
+
+### Type of change
+
+<!-- Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Other (specify): -->
+
+### How to test?
+
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce the behavior. Also, list any relevant details for your test configuration (e.g., OS, browser). -->
+
+### Screenshots (if applicable)
+
+<!-- If your change involves UI updates or changes, please include screenshots or GIFs that show the updates.  -->
+
+### Additional Context
+
+<!-- Add any other context or information that reviewers should know regarding this PR. You may also include tips on how to test this or key points to pay attention to during the review. -->


### PR DESCRIPTION
Fixes #191 and #192  

- Created yml templates for Bugs and Feature
  - I commented out `checkboxes` secition. Lmk if you would like to activate it
- Created md template for Pull Request
  - The current format for PR Title is `RADFish - [Component]: [Brief description of the change] (#IssueNumber)`. Please let me know if you would like any updates to it. 

Note: We won't be able to see these changes until this PR is merged