### PR TITLE
Fix table sorting when pagination options are not provided

### DIFF
--- a/packages/react-radfish/table/Table.spec.jsx
+++ b/packages/react-radfish/table/Table.spec.jsx
@@ -77,7 +77,7 @@ describe("Table", () => {
       totalRows: data.length,
     };
 
-    render(<Table data={data} columns={columns} paginationOptions={paginationOptions} />);
+    render(<Table data={data} columns={columns} />);
 
     // First click on Age sorts by Age ascending
     fireEvent.click(screen.getByText("Age"));

--- a/packages/react-radfish/table/index.jsx
+++ b/packages/react-radfish/table/index.jsx
@@ -140,7 +140,7 @@ const RADFishTable = ({
         pageIndex * paginationOptions.pageSize,
         (pageIndex + 1) * paginationOptions.pageSize,
       )
-    : data;
+    : sortedData;
 
   useEffect(() => {
     if (paginationOptions?.currentPage) {


### PR DESCRIPTION
There was a conditional check on pagination options that would fallback to unsorted data.

- Changed the data assignment to use `sortedData` instead of `data` when pagination options are not provided.