### PR TITLE
Fix ErrorBoundary import in table test

### DIFF
--- a/packages/react-radfish/table/Table.spec.jsx
+++ b/packages/react-radfish/table/Table.spec.jsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { ErrorBoundary } from "..";
+import { ErrorBoundary } from "../ErrorBoundary";
 import { render, screen, fireEvent, within, act } from "@testing-library/react";
 import { Table } from "./index";
 


### PR DESCRIPTION
The node-style import was having issues resolving the ErrorBoundary component in the Table tests.