### PR TITLE
Update field validators example dependencies

### DIFF
--- a/examples/field-validators/package.json
+++ b/examples/field-validators/package.json
@@ -7,8 +7,8 @@
     "@nmfs-radfish/radfish": "^0.2.2",
     "@nmfs-radfish/react-radfish": "^0.4.11",
     "@tanstack/react-table": "^8.11.7",
-    "@testing-library/user-event": "^13.5.0",
-    "@trussworks/react-uswds": "^6.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@trussworks/react-uswds": "^9.1.0",
     "dexie": "^3.2.5",
     "dexie-react-hooks": "^1.1.7",
     "react": "^18.2.0",
@@ -72,15 +72,15 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "jsdom": "24.0.0",
+    "jsdom": "25.0.1",
     "msw": "^2.0.12",
     "pptr-testing-library": "^0.8.0",
     "prettier": "^3.1.0",
     "puppeteer": "^22.6.5",
     "react-test-renderer": "^18.2.0",
     "vite": "^5.1.5",
-    "vite-plugin-pwa": "0.19.2",
-    "vitest": "1.4.0"
+    "vite-plugin-pwa": "0.20.5",
+    "vitest": "2.1.2"
   },
   "msw": {
     "workerDirectory": "public"


### PR DESCRIPTION
- **Bump vite-plugin-pwa from 0.19.2 to 0.20.5 in /examples/field-validators**
- **Bump @trussworks/react-uswds in /examples/field-validators**
- **Bump jsdom from 24.0.0 to 25.0.1 in /examples/field-validators**
- **Bump @testing-library/user-event in /examples/field-validators**
- **Bump vitest from 1.4.0 to 2.1.2 in /examples/field-validators**