### PR TITLE
Update server sync example dependencies

### DIFF
--- a/examples/server-sync/package.json
+++ b/examples/server-sync/package.json
@@ -7,8 +7,8 @@
     "@nmfs-radfish/radfish": "0.x",
     "@nmfs-radfish/react-radfish": "0.x",
     "@tanstack/react-table": "^8.11.7",
-    "@testing-library/user-event": "^13.5.0",
-    "@trussworks/react-uswds": "^6.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@trussworks/react-uswds": "^9.1.0",
     "dexie": "^3.2.5",
     "dexie-react-hooks": "^1.1.7",
     "react": "^18.2.0",
@@ -70,15 +70,15 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "jsdom": "24.0.0",
+    "jsdom": "25.0.1",
     "msw": "^2.0.12",
     "pptr-testing-library": "^0.8.0",
     "prettier": "^3.2.5",
     "puppeteer": "^22.6.5",
     "react-test-renderer": "^18.2.0",
     "vite": "^5.1.5",
-    "vite-plugin-pwa": "0.19.2",
-    "vitest": "1.4.0"
+    "vite-plugin-pwa": "0.20.5",
+    "vitest": "2.1.2"
   },
   "msw": {
     "workerDirectory": "public"


### PR DESCRIPTION
- **Bump vite-plugin-pwa from 0.19.2 to 0.20.5 in /examples/server-sync**
- **Bump @trussworks/react-uswds in /examples/server-sync**
- **Bump jsdom from 24.0.0 to 25.0.1 in /examples/server-sync**
- **Bump @testing-library/user-event in /examples/server-sync**
- **Bump vitest from 1.4.0 to 2.1.2 in /examples/server-sync**