### PR TITLE
Simple Table - className error on spinner component

### DIFF
--- a/packages/react-radfish/spinner/index.jsx
+++ b/packages/react-radfish/spinner/index.jsx
@@ -8,7 +8,7 @@ export const Spinner = ({
 }) => {
   return (
     <div
-      class="loading"
+      className="loading"
       style={{ borderTopColor: color, borderWidth: stroke, width, height }}
     ></div>
   );


### PR DESCRIPTION
issue #371 

Change to `className` in `Spinner` component