### PR TITLE
Update Dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       - "/examples/simple-table"
     schedule:
       interval: "weekly"
+      day: "thursday"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major" , "version-update:semver-patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
       - "/examples/simple-table"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major" , "version-update:semver-patch"]


### PR DESCRIPTION
The schedule is being updated to run on Thrusday instead of Monday. This should give more time to address package updates before weekly releases are scheduled to go out.

Additionally, relaxed Dependabot to only check for minor patch updates. This should reduce the amount of pull requests that are opened each week.