### PR TITLE
Bump template dependencies to latest patched versions

### DIFF
--- a/templates/react-javascript/package-lock.json
+++ b/templates/react-javascript/package-lock.json
@@ -2832,9 +2832,9 @@
       }
     },
     "node_modules/@nmfs-radfish/react-radfish": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@nmfs-radfish/react-radfish/-/react-radfish-0.5.5.tgz",
-      "integrity": "sha512-OXEq0BEYw+KTdnkBYlf+AawePiXDlMtV9UIGQuBHjKzEluRfNC/R+2bQS1SCySZ1AozCCyaOy0RfDZ+VhAfNjw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@nmfs-radfish/react-radfish/-/react-radfish-0.5.6.tgz",
+      "integrity": "sha512-iP8v9WjqciX4lDMrvBwVZx1s9I9HfU9H4UIOjNoIPpPun9GSphHydVZctJEeAbW9PVGKvfCV/wwOiAhlf7/EhA==",
       "dependencies": {
         "@tanstack/react-table": "^8.16.0",
         "@trussworks/react-uswds": "^9.0.0"


### PR DESCRIPTION
The package lock wasn't updated in the last release, so creating a project through the CLI was not receiving the changes from the [latest release](https://github.com/NMFS-RADFish/boilerplate/releases/tag/0.20.0).