### PR TITLE
442 Remove double headers in example READMEs

### DIFF
--- a/examples/computed-form-fields/README.md
+++ b/examples/computed-form-fields/README.md
@@ -123,7 +123,7 @@ const handleNumberFishChange = (event, formData) => {
     });
 };
 ```
-
-## Computed Form Fields Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Computed Form Fields](./src/assets/computed-form-fields.png)

--- a/examples/conditional-form-fields/README.md
+++ b/examples/conditional-form-fields/README.md
@@ -121,7 +121,7 @@ const handleFullNameChange = (event, formData) => {
     });
 };
 ```
-
-## Conditional Form Fields Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Conditional Form Fields](./src/assets/conditional-form-fields.png)

--- a/examples/field-validators/README.md
+++ b/examples/field-validators/README.md
@@ -88,7 +88,7 @@ Then, we can update the properties on our input to ensure that the validation lo
   validationErrors[FULL_NAME] && <ErrorMessage>{validationErrors[FULL_NAME]}</ErrorMessage>;
 }
 ```
-
-## Field Validators Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Field Validators](./src/assets/field-validators.png)

--- a/examples/form-structure/README.md
+++ b/examples/form-structure/README.md
@@ -116,7 +116,7 @@ const handleSubmit = (event) => {
     setResetToggle(true)
 }
 ```
-
-## Form Structure Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Form Structure](./src/assets/form-structure.png)

--- a/examples/mock-api/README.md
+++ b/examples/mock-api/README.md
@@ -203,7 +203,7 @@ const { data } = await postRequestWithFetch(MSW_ENDPOINT.SPECIES, {
   },
 });
 ```
-
-## Mock API Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Mock API](./src/assets/mock-api.png)

--- a/examples/multistep-form/README.md
+++ b/examples/multistep-form/README.md
@@ -125,7 +125,7 @@ useEffect(() => {
   );
 }
 ```
-
-## Multistep Form Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Multistep Form](./src/assets/multistep.png)

--- a/examples/network-status/README.md
+++ b/examples/network-status/README.md
@@ -29,6 +29,7 @@ Learn more about RADFish examples at the official [documentation](https://nmfs-r
    }, [isOffline]);
    ```
 
-## Network Status Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Network Status](./src/assets/network-status.png)

--- a/examples/on-device-storage/README.md
+++ b/examples/on-device-storage/README.md
@@ -79,6 +79,7 @@ The `useOfflineStorage` hook returns an object with the following methods:
   - Returns a promise that resolves to the updated data as an object:
     `{ numberOfFish: 10, species: salmon }`
 
-## On-Device Storage Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![On-Device Storage](./src/assets/on-device-storage.png)

--- a/examples/persisted-form/README.md
+++ b/examples/persisted-form/README.md
@@ -116,6 +116,7 @@ return (
 
 4. Construct your form using the `react-radfish` components. See the `/src/pages/Form.jsx` file to see how to construct the form and use the methods available from `FormWrapper`.
 
-## Persisted Form Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Persisted Form](./src/assets/persisted-form.png)

--- a/examples/react-query/README.md
+++ b/examples/react-query/README.md
@@ -8,6 +8,7 @@ This example does _not_ include any backend persistence via IndexedDB, as this i
 
 `[GET] /species` returns a list of 4 species
 
-## React Query Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![React Query](./src/assets/react-query.png)

--- a/examples/server-sync/README.md
+++ b/examples/server-sync/README.md
@@ -187,6 +187,7 @@ export const ServerSync = () => {
 };
 ```
 
-## Server Sync Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Server Sync](./src/assets/server-sync.png)

--- a/examples/simple-table/README.md
+++ b/examples/simple-table/README.md
@@ -168,6 +168,7 @@ You can pass these props directly to the `<Table>` component to enhance its styl
 
 For a complete list of available props and detailed descriptions, please refer to the [Trussworks Table Component Documentation](https://trussworks.github.io/react-uswds/?path=/docs/components-table--docs).
 
-## Simple Table Example Preview
+## Preview
+This example will render as shown in this screenshot:
 
 ![Simple Table](./src/assets/simple-table.png)


### PR DESCRIPTION
Updated header to keep in side nav and updated text to describe image.