### PR TITLE
Update NavDropDownButton caret to white

### DIFF
--- a/templates/react-javascript/src/index.css
+++ b/templates/react-javascript/src/index.css
@@ -20,3 +20,9 @@ html,
 body {
   width: 100%;
 }
+
+@media (min-width: 64em) {
+  .usa-nav__primary button[aria-expanded=false] span:after {
+      background: white;
+  }
+}


### PR DESCRIPTION
issue #672 

- Get `NavDropDownButton` caret icon selector and set to color white

![Screenshot 2025-03-05 at 9 37 55 PM](https://github.com/user-attachments/assets/55913d75-8a80-4215-965b-52ac14b959ff)
