### PR TITLE
Remove debug code

### DIFF
--- a/packages/radfish/index.js
+++ b/packages/radfish/index.js
@@ -98,8 +98,6 @@ export class Application {
       
       // Wait for all stores to be initialized
       await Promise.all(storeInitPromises);
-      console.log(storeInitPromises[0])
-      console.log(this.stores.weatherSurvey.connector.collections);
     }
 
     // Dispatch the init event

--- a/packages/radfish/package.json
+++ b/packages/radfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nmfs-radfish/radfish",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "scripts": {
     "test": "jest"

--- a/templates/react-javascript/package-lock.json
+++ b/templates/react-javascript/package-lock.json
@@ -2806,9 +2806,9 @@
       }
     },
     "node_modules/@nmfs-radfish/radfish": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nmfs-radfish/radfish/-/radfish-1.1.0.tgz",
-      "integrity": "sha512-U4eW4yui4kkb6mV0ImRik3DMPzn90UxVSeEInhen+AFILP5eRhumwlUYvyAhA5pnbOS7zD15azWehiATsw+baw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nmfs-radfish/radfish/-/radfish-1.1.1.tgz",
+      "integrity": "sha512-JuJn7wqlnNOxoyNnodabp3wsy0YPci8DYkIctuDX4m6DtJOnHUGrzIpZW7cfu/6WBn+MGwqgJijgPanMLQwc+A==",
       "dependencies": {
         "dexie": "4.0.x",
         "msw": "^2.3.1",


### PR DESCRIPTION
Accidentally, included some debugging code in the 1.1.0 release that was referencing a `weatherSurvey` store.

Probably should probably add a linter check to help prevent these types of errors from making it into the main branch.