### PR TITLE
Fix @nmfs-radfish/radfish package export to correctly be a ESM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "description": "![test and build workflow](https://github.com/NMFS-RADFish/boilerplate/actions/workflows/run-tests.yml/badge.svg)",
   "workspaces": [
-    "./packages/radfish",
-    "./packages/react-radfish"
+    "packages/radfish",
+    "packages/react-radfish"
   ],
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The `@nmfs-radfish/radfish` does not properly define itself as an ESM module. This can cause issues with bundlers when resolving imports.

These changes correct this issue by declaring this package as an ESM module.