### PR TITLE
chore: Bump nodejs version in runners to v20

### DIFF
--- a/.github/workflows/publish-radfish.yml
+++ b/.github/workflows/publish-radfish.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "20"
           registry-url: 'https://registry.npmjs.org'
           
       - name: Install dependencies

--- a/.github/workflows/publish-react-radfish.yml
+++ b/.github/workflows/publish-react-radfish.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "20"
           registry-url: 'https://registry.npmjs.org'
           
       - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: .
 
       - name: Install dependencies
-        run: npm install --legacy-peer-deps
+        run: npm install
         working-directory: templates/react-javascript
 
       - name: Build project

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install workspace dependencies
         run: npm install --legacy-peer-deps


### PR DESCRIPTION
Bumped the Nodejs version to 20 in runners since 18 is no longer being maintained.
Removed `--legacy-peer-deps` flag from tests because it doesn't resolve an underlying uswds dependency correctly.